### PR TITLE
[RTM] nipype source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,6 @@ RUN conda config --add channels conda-forge && \
 WORKDIR /root/
 COPY . niworkflows/
 RUN cd niworkflows && \
-    pip install -e .[all] && \
+    pip install --process-dependency-links -e .[all] && \
     python -c 'from niworkflows.data.getters import get_mni_template_ras; get_mni_template_ras()' && \
     python -c 'from niworkflows.data.getters import get_ds003_downsampled; get_ds003_downsampled()'

--- a/niworkflows/info.py
+++ b/niworkflows/info.py
@@ -50,11 +50,10 @@ CLASSIFIERS = [
 ]
 
 REQUIRES = ['nipype', 'future', 'nilearn', 'sklearn', 'pandas', 'matplotlib',
-            'jinja2', 'svgutils', 'tinycss']
+            'jinja2', 'svgutils', 'tinycss', 'nipype']
 SETUP_REQUIRES = []
 REQUIRES += SETUP_REQUIRES
 
-LINKS_REQUIRES = ['git+https://github.com/oesteban/nipype.git#egg=nipype',]
 TESTS_REQUIRES = ['mock', 'codecov', 'pytest-xdist']
 EXTRA_REQUIRES = {
     'doc': ['sphinx'],

--- a/niworkflows/info.py
+++ b/niworkflows/info.py
@@ -49,13 +49,13 @@ CLASSIFIERS = [
     'Programming Language :: Python :: 3.5',
 ]
 
-REQUIRES = ['nipype==dev', 'future', 'nilearn', 'sklearn', 'pandas', 'matplotlib',
+REQUIRES = ['nipype==8ddc', 'future', 'nilearn', 'sklearn', 'pandas', 'matplotlib',
             'jinja2', 'svgutils', 'tinycss']
 SETUP_REQUIRES = []
 REQUIRES += SETUP_REQUIRES
 
-LINKS_REQUIRES = ['git+https://github.com/nipy/nipype.git@8ddca5a03fcad26887c862dc23c82ef23f2ee506#egg=nipype-dev',]
-TESTS_REQUIRES = ['mock', 'codecov', 'pytest-xdist']
+LINKS_REQUIRES = ['git+https://github.com/nipy/nipype.git@8ddca5a03fcad26887c862dc23c82ef23f2ee506#egg=nipype-8ddc',]
+TESTS_REQUIRES = ['mock', 'codecov', 'pytest-xdist', 'nose']
 EXTRA_REQUIRES = {
     'doc': ['sphinx'],
     'tests': TESTS_REQUIRES,

--- a/niworkflows/info.py
+++ b/niworkflows/info.py
@@ -49,12 +49,12 @@ CLASSIFIERS = [
     'Programming Language :: Python :: 3.5',
 ]
 
-REQUIRES = ['nipype', 'future', 'nilearn', 'sklearn', 'pandas', 'matplotlib',
+REQUIRES = ['nipype==dev', 'future', 'nilearn', 'sklearn', 'pandas', 'matplotlib',
             'jinja2', 'svgutils', 'tinycss']
 SETUP_REQUIRES = []
 REQUIRES += SETUP_REQUIRES
 
-LINKS_REQUIRES = ['git+https://github.com/nipy/nipype.git@8ddca5a03fcad26887c862dc23c82ef23f2ee506#egg=nipype',]
+LINKS_REQUIRES = ['git+https://github.com/nipy/nipype.git@8ddca5a03fcad26887c862dc23c82ef23f2ee506#egg=nipype-dev',]
 TESTS_REQUIRES = ['mock', 'codecov', 'pytest-xdist']
 EXTRA_REQUIRES = {
     'doc': ['sphinx'],

--- a/niworkflows/info.py
+++ b/niworkflows/info.py
@@ -54,6 +54,7 @@ REQUIRES = ['nipype', 'future', 'nilearn', 'sklearn', 'pandas', 'matplotlib',
 SETUP_REQUIRES = []
 REQUIRES += SETUP_REQUIRES
 
+LINKS_REQUIRES = []
 TESTS_REQUIRES = ['mock', 'codecov', 'pytest-xdist']
 EXTRA_REQUIRES = {
     'doc': ['sphinx'],

--- a/niworkflows/info.py
+++ b/niworkflows/info.py
@@ -54,7 +54,7 @@ REQUIRES = ['nipype', 'future', 'nilearn', 'sklearn', 'pandas', 'matplotlib',
 SETUP_REQUIRES = []
 REQUIRES += SETUP_REQUIRES
 
-LINKS_REQUIRES = []
+LINKS_REQUIRES = ['git+https://github.com/nipy/nipype.git@8ddca5a03fcad26887c862dc23c82ef23f2ee506#egg=nipype',]
 TESTS_REQUIRES = ['mock', 'codecov', 'pytest-xdist']
 EXTRA_REQUIRES = {
     'doc': ['sphinx'],

--- a/niworkflows/info.py
+++ b/niworkflows/info.py
@@ -50,7 +50,7 @@ CLASSIFIERS = [
 ]
 
 REQUIRES = ['nipype', 'future', 'nilearn', 'sklearn', 'pandas', 'matplotlib',
-            'jinja2', 'svgutils', 'tinycss', 'nipype']
+            'jinja2', 'svgutils', 'tinycss']
 SETUP_REQUIRES = []
 REQUIRES += SETUP_REQUIRES
 

--- a/niworkflows/interfaces/registration.py
+++ b/niworkflows/interfaces/registration.py
@@ -27,7 +27,7 @@ class FLIRTRPT(nrc.RegistrationRC, fsl.FLIRT):
 
 
 class ApplyXFMInputSpecRPT(nrc.RegistrationRCInputSpec,
-                           fsl.preprocess.ApplyXfmInputSpec):
+                           fsl.preprocess.ApplyXFMInputSpec):
     pass
 
 class ApplyXFMRPT(FLIRTRPT):


### PR DESCRIPTION
This PR fixes nipype dependency. Previously defined dependency_links was ignored and the latest release of nipype was always used (which is probably why @shoshber attempts to use her own fork of nipype in #36 did not work).

I assumed that using nipype master is intended and it might be temporarily necessary. For pypy releases we should not use dependency_links and only depend on relesed packages.