### PR TITLE
WIP/ENH plot outline of FLIRT input wm_seg

### DIFF
--- a/niworkflows/common/report.py
+++ b/niworkflows/common/report.py
@@ -126,7 +126,10 @@ class RegistrationRC(ReportCapableInterface):
 
         fixed_image_nii = load_img(self._fixed_image)
         moving_image_nii = load_img(self._moving_image)
-        contour_nii = load_img(self._contour) if self._contour is not None else None
+        if hasattr(self, '_contour') and self._contour is not None:
+            contour_nii = load_img(self._contour)
+        else:
+            contour_nii = None
 
         if self._fixed_image_mask:
             fixed_image_nii = unmask(apply_mask(fixed_image_nii,

--- a/niworkflows/common/report.py
+++ b/niworkflows/common/report.py
@@ -125,8 +125,8 @@ class RegistrationRC(ReportCapableInterface):
         NIWORKFLOWS_LOG.info('Generating visual report')
 
         fixed_image_nii = load_img(self._fixed_image)
-        fixed_contour_nii = load_img(self._fixed_contour) if self._fixed_contour is not None else None
         moving_image_nii = load_img(self._moving_image)
+        contour_nii = load_img(self._contour) if self._contour is not None else None
 
         if self._fixed_image_mask:
             fixed_image_nii = unmask(apply_mask(fixed_image_nii,
@@ -142,22 +142,23 @@ class RegistrationRC(ReportCapableInterface):
             mask_nii = threshold_img(fixed_image_nii, 1e-3)
 
         cuts = cuts_from_bbox(mask_nii, cuts=7)
+
         # Call composer
         compose_view(
             plot_registration(fixed_image_nii, 'fixed-image',
                               estimate_brightness=True,
                               cuts=cuts,
                               label=self._fixed_image_label,
-                              contour=fixed_contour_nii),
+                              contour=contour_nii),
             plot_registration(moving_image_nii, 'moving-image',
                               estimate_brightness=True,
                               cuts=cuts,
-                              label=self._moving_image_label),
+                              label=self._moving_image_label,
+                              contour=contour_nii),
             out_file=self._out_report)
 
 
 class SegmentationRC(ReportCapableInterface):
-
     """ An abstract mixin to segmentation nipype interfaces """
 
     def _generate_report(self):

--- a/niworkflows/common/report.py
+++ b/niworkflows/common/report.py
@@ -7,7 +7,6 @@ import os
 from sys import version_info
 from abc import abstractmethod
 from io import open
-from nilearn.image import load_img
 
 from nipype.interfaces.base import File, traits, BaseInterface, BaseInterfaceInputSpec, TraitedSpec
 from niworkflows import NIWORKFLOWS_LOG
@@ -126,6 +125,7 @@ class RegistrationRC(ReportCapableInterface):
         NIWORKFLOWS_LOG.info('Generating visual report')
 
         fixed_image_nii = load_img(self._fixed_image)
+        fixed_contour_nii = load_img(self._fixed_contour) if self._fixed_contour is not None else None
         moving_image_nii = load_img(self._moving_image)
 
         if self._fixed_image_mask:
@@ -147,7 +147,8 @@ class RegistrationRC(ReportCapableInterface):
             plot_registration(fixed_image_nii, 'fixed-image',
                               estimate_brightness=True,
                               cuts=cuts,
-                              label=self._fixed_image_label),
+                              label=self._fixed_image_label,
+                              contour=fixed_contour_nii),
             plot_registration(moving_image_nii, 'moving-image',
                               estimate_brightness=True,
                               cuts=cuts,

--- a/niworkflows/common/report.py
+++ b/niworkflows/common/report.py
@@ -117,6 +117,7 @@ class RegistrationRC(ReportCapableInterface):
         self._fixed_image_mask = None
         self._fixed_image_label = "fixed"
         self._moving_image_label = "moving"
+        self._contour = None
         super(RegistrationRC, self).__init__(**inputs)
 
     def _generate_report(self):
@@ -126,10 +127,7 @@ class RegistrationRC(ReportCapableInterface):
 
         fixed_image_nii = load_img(self._fixed_image)
         moving_image_nii = load_img(self._moving_image)
-        if hasattr(self, '_contour') and self._contour is not None:
-            contour_nii = load_img(self._contour)
-        else:
-            contour_nii = None
+        contour_nii = load_img(self._contour) if self._contour is not None else None
 
         if self._fixed_image_mask:
             fixed_image_nii = unmask(apply_mask(fixed_image_nii,

--- a/niworkflows/common/report.py
+++ b/niworkflows/common/report.py
@@ -159,6 +159,7 @@ class RegistrationRC(ReportCapableInterface):
 
 
 class SegmentationRC(ReportCapableInterface):
+
     """ An abstract mixin to segmentation nipype interfaces """
 
     def _generate_report(self):

--- a/niworkflows/interfaces/registration.py
+++ b/niworkflows/interfaces/registration.py
@@ -110,6 +110,7 @@ class FLIRTRPT(nrc.RegistrationRC, fsl.FLIRT):
 
     def _post_run_hook(self, runtime):
         self._fixed_image = self.inputs.reference
+        self._fixed_contour = self.inputs.wm_seg if isdefined(self.inputs.wm_seg) else None
         self._moving_image = self.aggregate_outputs().out_file
         NIWORKFLOWS_LOG.info(
             'Report - setting fixed (%s) and moving (%s) images',

--- a/niworkflows/interfaces/registration.py
+++ b/niworkflows/interfaces/registration.py
@@ -110,8 +110,8 @@ class FLIRTRPT(nrc.RegistrationRC, fsl.FLIRT):
 
     def _post_run_hook(self, runtime):
         self._fixed_image = self.inputs.reference
-        self._fixed_contour = self.inputs.wm_seg if isdefined(self.inputs.wm_seg) else None
         self._moving_image = self.aggregate_outputs().out_file
+        self._contour = self.inputs.wm_seg if isdefined(self.inputs.wm_seg) else None
         NIWORKFLOWS_LOG.info(
             'Report - setting fixed (%s) and moving (%s) images',
             self._fixed_image, self._moving_image)

--- a/niworkflows/tests/test_reports.py
+++ b/niworkflows/tests/test_reports.py
@@ -40,39 +40,37 @@ class TestRegistrationInterfaces(unittest.TestCase):
 
     def test_FLIRTRPT(self):
         """ the FLIRT report capable test """
-        with InTemporaryDirectory():
-            flirt_rpt = FLIRTRPT(generate_report=True, in_file=self.moving,
-                                 reference=self.reference)
-            _smoke_test_report(flirt_rpt, 'testFLIRT.svg')
+        flirt_rpt = FLIRTRPT(generate_report=True, in_file=self.moving,
+                             reference=self.reference)
+        _smoke_test_report(flirt_rpt, 'testFLIRT.svg')
+
+    def test_FLIRTRPT_w_BBR(self):
+        """ test FLIRTRPT with input `wm_seg` set.
+        For the sake of testing ONLY, `wm_seg` is set to the filename of a brain mask """
+        flirt_rpt = FLIRTRPT(generate_report=True, in_file=self.moving,
+                             reference=self.reference, wm_seg=self.reference_mask)
+        _smoke_test_report(flirt_rpt, 'testFLIRTRPTBBR.svg')
 
     def test_RobustMNINormalizationRPT(self):
         """ the RobustMNINormalizationRPT report capable test """
-        with InTemporaryDirectory():
-            ants_rpt = RobustMNINormalizationRPT(
-                generate_report=True, moving_image=self.moving, testing=True)
-            _smoke_test_report(ants_rpt, 'testRobustMNINormalizationRPT.svg')
+        ants_rpt = RobustMNINormalizationRPT(
+            generate_report=True, moving_image=self.moving, testing=True)
+        _smoke_test_report(ants_rpt, 'testRobustMNINormalizationRPT.svg')
 
     def test_RobustMNINormalizationRPT_masked(self):
         """ the RobustMNINormalizationRPT report capable test with masking """
-        with InTemporaryDirectory():
-            ants_rpt = RobustMNINormalizationRPT(
-                generate_report=True, moving_image=self.moving,
-                reference_mask=self.reference_mask, testing=True)
-            _smoke_test_report(ants_rpt, 'testRobustMNINormalizationRPT_masked.svg')
+        ants_rpt = RobustMNINormalizationRPT(
+            generate_report=True, moving_image=self.moving,
+            reference_mask=self.reference_mask, testing=True)
+        _smoke_test_report(ants_rpt, 'testRobustMNINormalizationRPT_masked.svg')
 
     def test_ANTSRegistrationRPT(self):
         """ the RobustMNINormalizationRPT report capable test """
-        with InTemporaryDirectory():
-            ants_rpt = ANTSRegistrationRPT(
-                generate_report=True, moving_image=self.moving, fixed_image=self.reference,
-                from_file=pkgr.resource_filename(
-                    'niworkflows.data', 't1-mni_registration_testing_000.json'))
-            _smoke_test_report(ants_rpt, 'testANTSRegistrationRPT.svg')
-
-
-
-#     #def test_applyxfm_wrapper(self):
-#     #    self.test_known_file_out(ApplyXFMRPT)
+        ants_rpt = ANTSRegistrationRPT(
+            generate_report=True, moving_image=self.moving, fixed_image=self.reference,
+            from_file=pkgr.resource_filename(
+                'niworkflows.data', 't1-mni_registration_testing_000.json'))
+        _smoke_test_report(ants_rpt, 'testANTSRegistrationRPT.svg')
 
 class TestBETRPT(unittest.TestCase):
     ''' tests it using mni as in_file '''

--- a/niworkflows/viz/utils.py
+++ b/niworkflows/viz/utils.py
@@ -64,11 +64,9 @@ def save_html(template, report_file_name, unique_string, **kwargs):
         handle.write(report_render)
 
 
-def as_svg(image):
+def as_svg(image, filename='temp.svg'):
     ''' takes an image as created by nilearn.plotting and returns a blob svg.
     A bit hacky. '''
-    filename = 'temp.svg'
-
     image.savefig(filename)
     with open(filename, 'r' if PY3 else 'rb') as file_obj:
         image_svg = file_obj.readlines()
@@ -190,7 +188,7 @@ def plot_xyz(image, plot_func, cuts, plot_params=None, dimensions=('z', 'x', 'y'
 
 def plot_registration(anat_nii, div_id, plot_params=None,
                       order=('z', 'x', 'y'), cuts=None,
-                      estimate_brightness=False, label=None):
+                      estimate_brightness=False, label=None, contour=None):
     """
     Plots the foreground and background views
     Default order is: axial, coronal, sagittal
@@ -212,19 +210,18 @@ def plot_registration(anat_nii, div_id, plot_params=None,
         out_file = '{}_{}.svg'.format(div_id, mode)
         plot_params['display_mode'] = mode
         plot_params['cut_coords'] = cuts[mode]
-        plot_params['output_file'] = out_file
         if i == 0:
             plot_params['title'] = label
         else:
             plot_params['title'] = None
 
         # Generate nilearn figure
-        plot_anat(anat_nii, **plot_params)
-        out_files.append(out_file)
+        display = plot_anat(anat_nii, **plot_params)
+        if contour is not None:
+            display.add_contours(contour, levels=[.9])
 
-        # Open generated svg file and fix id
-        with open(out_file, 'rb') as f:
-            svg = f.read()
+        out_files.append(out_file)
+        svg = as_svg(display, out_file)
 
         # Find and replace the figure_1 id.
         xml_data = etree.fromstring(svg)
@@ -296,4 +293,3 @@ def compose_view(bg_svgs, fg_svgs, ref=0, out_file='report.svg'):
     with open(out_file, 'w' if PY3 else 'wb') as f:
         f.write('\n'.join(svg))
     return out_file
-


### PR DESCRIPTION
In the artifacts on circle, it shows the outline of the brain mask. This is because it is more convenient in testing to use already-available files.

Here is what it looks like with a white matter outline: https://github.com/shoshber/pastebin/blob/master/reports/wm_mask.svg