### PR TITLE
[RTM] Added optional svg compression

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,15 @@ RUN conda config --add channels conda-forge && \
     conda install -y numpy scipy matplotlib pandas lxml libxslt nose mock && \
     python -c "from matplotlib import font_manager"
 
+RUN /bin/bash -c 'echo WEBP && \
+  wget -q "http://downloads.webmproject.org/releases/webp/libwebp-0.5.2-linux-x86-64.tar.gz" && \
+  tar -xf libwebp-0.5.2-linux-x86-64.tar.gz && cd libwebp-0.5.2-linux-x86-64/bin && \
+  mv cwebp /usr/local/bin/ && rm libwebp-0.5.2-linux-x86-64.tar.gz && rm -rf libwebp-0.5.2-linux-x86-64
+
+RUN curl -sL https://deb.nodesource.com/setup_6.x | bash -
+RUN apt-get install -y nodejs
+RUN npm install -g svgo
+
 RUN mkdir /niworkflows_data
 ENV CRN_SHARED_DATA /niworkflows_data
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,6 +63,7 @@ ENV CRN_SHARED_DATA /niworkflows_data
 
 WORKDIR /root/
 COPY . niworkflows/
+RUN find /root/niworkflows/ -name "test*.py" -exec chmod a-x '{}' \;
 RUN cd niworkflows && \
     pip install -e .[all] && \
     python -c 'from niworkflows.data.getters import get_mni_template_ras; get_mni_template_ras()' && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,10 +45,9 @@ RUN conda config --add channels conda-forge && \
     conda install -y numpy scipy matplotlib pandas lxml libxslt nose mock && \
     python -c "from matplotlib import font_manager"
 
-RUN /bin/bash -c 'echo WEBP && \
-  wget -q "http://downloads.webmproject.org/releases/webp/libwebp-0.5.2-linux-x86-64.tar.gz" && \
+RUN curl -sSLO "http://downloads.webmproject.org/releases/webp/libwebp-0.5.2-linux-x86-64.tar.gz" && \
   tar -xf libwebp-0.5.2-linux-x86-64.tar.gz && cd libwebp-0.5.2-linux-x86-64/bin && \
-  mv cwebp /usr/local/bin/ && rm libwebp-0.5.2-linux-x86-64.tar.gz && rm -rf libwebp-0.5.2-linux-x86-64
+  mv cwebp /usr/local/bin/ && rm -rf libwebp-0.5.2-linux-x86-64
 
 RUN curl -sL https://deb.nodesource.com/setup_6.x | bash -
 RUN apt-get install -y nodejs

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ RUN curl -sSLO "http://downloads.webmproject.org/releases/webp/libwebp-0.5.2-lin
   tar -xf libwebp-0.5.2-linux-x86-64.tar.gz && cd libwebp-0.5.2-linux-x86-64/bin && \
   mv cwebp /usr/local/bin/ && rm -rf libwebp-0.5.2-linux-x86-64
 
-RUN curl -sL https://deb.nodesource.com/setup_6.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_7.x | bash -
 RUN apt-get install -y nodejs
 RUN npm install -g svgo
 

--- a/niworkflows/common/report.py
+++ b/niworkflows/common/report.py
@@ -23,6 +23,11 @@ class ReportCapableInputSpec(BaseInterfaceInputSpec):
         False, usedefault=True, desc="Set to true to enable report generation for node")
     out_report = File(
         'report.html', usedefault=True, desc='filename for the visual report')
+    compress_report = traits.Enum('auto', True, False, usedefault=True,
+                                  desc="Compress the reportlet using SVGO or"
+                                       "WEBP. 'auto' - compress if relevant "
+                                       "software is installed, True = force,"
+                                       "False - don't attempt to compress")
 
 
 class ReportCapableOutputSpec(TraitedSpec):
@@ -154,12 +159,14 @@ class RegistrationRC(ReportCapableInterface):
                               estimate_brightness=True,
                               cuts=cuts,
                               label=self._fixed_image_label,
-                              contour=contour_nii),
+                              contour=contour_nii,
+                              compress=self.inputs.copress_report),
             plot_registration(moving_image_nii, 'moving-image',
                               estimate_brightness=True,
                               cuts=cuts,
                               label=self._moving_image_label,
-                              contour=contour_nii),
+                              contour=contour_nii,
+                              compress=self.inputs.copress_report),
             out_file=self._out_report
         )
 
@@ -176,5 +183,6 @@ class SegmentationRC(ReportCapableInterface):
             mask_nii=self._mask_file,
             out_file=self.inputs.out_report,
             masked=self._masked,
-            title=self._report_title
+            title=self._report_title,
+            compress=self.inputs.compress_report
         )

--- a/niworkflows/common/report.py
+++ b/niworkflows/common/report.py
@@ -160,13 +160,13 @@ class RegistrationRC(ReportCapableInterface):
                               cuts=cuts,
                               label=self._fixed_image_label,
                               contour=contour_nii,
-                              compress=self.inputs.copress_report),
+                              compress=self.inputs.compress_report),
             plot_registration(moving_image_nii, 'moving-image',
                               estimate_brightness=True,
                               cuts=cuts,
                               label=self._moving_image_label,
                               contour=contour_nii,
-                              compress=self.inputs.copress_report),
+                              compress=self.inputs.compress_report),
             out_file=self._out_report
         )
 

--- a/niworkflows/tests/test_reports.py
+++ b/niworkflows/tests/test_reports.py
@@ -184,8 +184,8 @@ class TestCompression(unittest.TestCase):
         compressed_report = compressed_int.inputs.out_report
 
         unittest.TestCase.assertTrue(int(os.stat(uncompressed_report).st_size) > int(os.stat(compressed_report).st_size),
-                                        'An uncompressed report is bigger than '
-                                        'a compressed report')
+                                     'An uncompressed report is bigger than '
+                                     'a compressed report')
 
 
 class TestReconAllRPT(unittest.TestCase):

--- a/niworkflows/tests/test_reports.py
+++ b/niworkflows/tests/test_reports.py
@@ -160,3 +160,22 @@ class TestFASTRPT(unittest.TestCase):
                                    probability_maps=True, out_basename='test')
 
         _smoke_test_report(report_interface, 'testFAST_no_segments.html')
+
+
+class TestCompression(unittest.TestCase):
+
+    def test_compression(self):
+        ''' test if compression makes files smaller '''
+        uncompressed_int = BETRPT(in_file=MNI_2MM, generate_report=True,
+                                  mask=True, compress_report=False)
+        uncompressed_int.run()
+        uncompressed_report = uncompressed_int.inputs.out_report
+
+        compressed_int = BETRPT(in_file=MNI_2MM, generate_report=True,
+                                mask=True, compress_report=True)
+        compressed_int.run()
+        compressed_report = compressed_int.inputs.out_report
+
+        unittest.TestCase.assertTrue(int(os.stat(uncompressed_report).st_size) > int(os.stat(compressed_report).st_size),
+                                        'An uncompressed report is bigger than '
+                                        'a compressed report')

--- a/niworkflows/viz/utils.py
+++ b/niworkflows/viz/utils.py
@@ -68,7 +68,7 @@ def save_html(template, report_file_name, unique_string, **kwargs):
         handle.write(report_render)
 
 
-def as_svg(image, filename='temp.svg', compress=True, force=False):
+def as_svg(image, filename='temp.svg', compress='auto'):
     ''' takes an image as created by nilearn.plotting and returns a blob svg.
     Performs compression (can be disabled). A bit hacky. '''
 
@@ -82,7 +82,7 @@ def as_svg(image, filename='temp.svg', compress=True, force=False):
     image.savefig(svg_file)
 
     # Compress the SVG file using SVGO
-    if (shutil.which("svgo") and compress) or force:
+    if (shutil.which("svgo") and compress == 'auto') or compress == True:
         out_file = op.join(tmp_dir, "svgo_out.svg")
         subprocess.check_call("svgo -i %s -o %s -q -p 3 --pretty --disable=cleanupNumericValues" % (svg_file,
                                                                   out_file),
@@ -90,7 +90,7 @@ def as_svg(image, filename='temp.svg', compress=True, force=False):
         svg_file = out_file
 
     # Convert all of the rasters inside the SVG file with 80% compressed WEBP
-    if (shutil.which("cwebp") and compress) or force:
+    if (shutil.which("cwebp") and compress == 'auto') or compress == True:
         new_lines = []
         with open(svg_file, 'r') as fp:
             for line in fp:
@@ -180,7 +180,8 @@ def _3d_in_file(in_file):
     return nlimage.index_img(in_file, 0)
 
 
-def plot_segs(image_nii, seg_niis, mask_nii, out_file, masked=False, title=None, **plot_params):
+def plot_segs(image_nii, seg_niis, mask_nii, out_file, masked=False, title=None,
+              compress='auto', **plot_params):
     """ plot segmentation as contours over the image (e.g. anatomical).
     seg_niis should be a list of files. mask_nii helps determine the cut
     coordinates. plot_params will be passed on to nilearn plot_* functions. If
@@ -204,7 +205,7 @@ def plot_segs(image_nii, seg_niis, mask_nii, out_file, masked=False, title=None,
             plot_params['alpha'] = 1
             svg.add_contours(seg, **plot_params)
 
-        svgs_list.append(as_svg(svg))
+        svgs_list.append(as_svg(svg, compress=compress))
         svg.close()
 
     plot_params = {} if plot_params is None else plot_params
@@ -246,7 +247,8 @@ def plot_xyz(image, plot_func, cuts, plot_params=None, dimensions=('z', 'x', 'y'
 
 def plot_registration(anat_nii, div_id, plot_params=None,
                       order=('z', 'x', 'y'), cuts=None,
-                      estimate_brightness=False, label=None, contour=None):
+                      estimate_brightness=False, label=None, contour=None,
+                      compress='auto'):
     """
     Plots the foreground and background views
     Default order is: axial, coronal, sagittal
@@ -292,7 +294,7 @@ def plot_registration(anat_nii, div_id, plot_params=None,
             display.add_contours(contour, levels=[.9])
 
         out_files.append(out_file)
-        svg = as_svg(display, out_file)
+        svg = as_svg(display, out_file, compress=compress)
         display.close()
 
         # Find and replace the figure_1 id.

--- a/niworkflows/viz/utils.py
+++ b/niworkflows/viz/utils.py
@@ -81,12 +81,16 @@ def as_svg(image, filename='temp.svg', compress=True, force=False):
 
     image.savefig(svg_file)
 
+`    # Compress the SVG file using SVGO
     if (shutil.which("svgo") and compress) or force:
         out_file = op.join(tmp_dir, "svgo_out.svg")
-        subprocess.check_call("svgo -i %s -o %s -p 3 --pretty"%(svg_file, out_file),
-            shell=True)
+        subprocess.check_call("svgo -i %s -o %s -p 3 --pretty" % (svg_file,
+                                                                  out_file),
+                              shell=True,
+                              stdout=subprocess.DEVNULL)
         svg_file = out_file
 
+    # Convert all of the rasters inside the SVG file with 80% compressed WEBP
     if (shutil.which("cwebp") and compress) or force:
         new_lines = []
         with open(svg_file, 'r') as fp:
@@ -111,7 +115,9 @@ def as_svg(image, filename='temp.svg', compress=True, force=False):
                         fp_png.write(bobj)
                     cwebp_out = op.join(tmp_dir, "cwebp_out.webp")
                     subprocess.check_call(["cwebp", "-noalpha", png_tmp, "-q",
-                                             "80", "-o", cwebp_out])
+                                             "80", "-o", cwebp_out],
+                                          shell=True,
+                                          stdout=subprocess.DEVNULL)
                     with open(cwebp_out, 'rb') as fp_webp:
                         webp_b64 = base64.b64encode(fp_webp.read()).decode(
                             "utf-8")

--- a/niworkflows/viz/utils.py
+++ b/niworkflows/viz/utils.py
@@ -83,8 +83,7 @@ def as_svg(image, filename='temp.svg', compress=True):
 
     if shutil.which("svgo") and compress:
         out_file = op.join(tmp_dir, "svgo_out.svg")
-        subprocess.check_output(
-            ["svgo", "-i", svg_file, "-p", "3", "--pretty", "-o", out_file],
+        subprocess.check_call("svgo -i %s -p 3 --pretty -o %s"%(svg_file, out_file),
             shell=True)
         svg_file = out_file
 

--- a/niworkflows/viz/utils.py
+++ b/niworkflows/viz/utils.py
@@ -84,7 +84,7 @@ def as_svg(image, filename='temp.svg', compress=True, force=False):
     # Compress the SVG file using SVGO
     if (shutil.which("svgo") and compress) or force:
         out_file = op.join(tmp_dir, "svgo_out.svg")
-        subprocess.check_call("svgo -i %s -o %s -q -p 3 --pretty" % (svg_file,
+        subprocess.check_call("svgo -i %s -o %s -q -p 3 --pretty --disable=cleanupNumericValues" % (svg_file,
                                                                   out_file),
                               shell=True)
         svg_file = out_file
@@ -318,7 +318,7 @@ def compose_view(bg_svgs, fg_svgs, ref=0, out_file='report.svg'):
     roots = [f.getroot() for f in svgs]
     nsvgs = len(svgs) // 2
     # Query the size of each
-    sizes = [(int(f.width[:-2]), int(f.height[:-2])) for f in svgs]
+    sizes = [(int(f.width.replace('pt', '')), int(f.height.replace('pt', ''))) for f in svgs]
 
     # Calculate the scale to fit all widths
     scales = [1.0] * len(svgs)

--- a/niworkflows/viz/utils.py
+++ b/niworkflows/viz/utils.py
@@ -83,7 +83,7 @@ def as_svg(image, filename='temp.svg', compress=True):
 
     if shutil.which("svgo") and compress:
         out_file = op.join(tmp_dir, "svgo_out.svg")
-        subprocess.run(
+        subprocess.check_output(
             ["svgo", "-i", svg_file, "-p", "3", "--pretty", "-o", out_file],
             shell=True)
         svg_file = out_file
@@ -112,8 +112,8 @@ def as_svg(image, filename='temp.svg', compress=True):
                     with open(png_tmp, 'r' if PY3 else 'rb') as fp_png:
                         fp_png.write(bobj)
                     cwebp_out = op.join(tmp_dir, "cwebp_out.webp")
-                    subprocess.run(["cwebp", "-noalpha", png_tmp, "-q",
-                                    "80", "-o", cwebp_out])
+                    subprocess.check_output(["cwebp", "-noalpha", png_tmp, "-q",
+                                             "80", "-o", cwebp_out])
                     with open(cwebp_out, 'r' if PY3 else 'rb') as fp_webp:
                         webp_b64 = base64.b64encode(fp_webp.read()).decode(
                             "utf-8")

--- a/niworkflows/viz/utils.py
+++ b/niworkflows/viz/utils.py
@@ -77,7 +77,7 @@ def svg_compress(image, compress='auto'):
     if (shutil.which("svgo") and compress == 'auto') or compress is True:
 
         p = subprocess.run("svgo -i - -o - -q -p 3 --pretty --disable=cleanupNumericValues",
-                           stdin=image.encode('utf-8'), stdout=subprocess.PIPE,
+                           input=image.encode('utf-8'), stdout=subprocess.PIPE,
                            shell=True, check=True)
         image = p.stdout.decode('utf-8')
 
@@ -101,7 +101,7 @@ def svg_compress(image, compress='auto'):
                     right = '"' + '"'.join(right.split('"')[1:])
 
                     p = subprocess.run("cwebp -quiet -noalpha -q 80 -o - -- -",
-                                       stdin=base64.b64decode(png_b64),
+                                       input=base64.b64decode(png_b64),
                                        stdout=subprocess.PIPE,
                                        shell=True, check=True)
                     webpimg = base64.b64encode(p.stdout).decode('utf-8')

--- a/niworkflows/viz/utils.py
+++ b/niworkflows/viz/utils.py
@@ -81,7 +81,7 @@ def as_svg(image, filename='temp.svg', compress=True, force=False):
 
     image.savefig(svg_file)
 
-`    # Compress the SVG file using SVGO
+    # Compress the SVG file using SVGO
     if (shutil.which("svgo") and compress) or force:
         out_file = op.join(tmp_dir, "svgo_out.svg")
         subprocess.check_call("svgo -i %s -o %s -p 3 --pretty" % (svg_file,

--- a/niworkflows/viz/utils.py
+++ b/niworkflows/viz/utils.py
@@ -84,10 +84,9 @@ def as_svg(image, filename='temp.svg', compress=True, force=False):
     # Compress the SVG file using SVGO
     if (shutil.which("svgo") and compress) or force:
         out_file = op.join(tmp_dir, "svgo_out.svg")
-        subprocess.check_call("svgo -i %s -o %s -p 3 --pretty" % (svg_file,
+        subprocess.check_call("svgo -i %s -o %s -q -p 3 --pretty" % (svg_file,
                                                                   out_file),
-                              shell=True,
-                              stdout=subprocess.DEVNULL)
+                              shell=True)
         svg_file = out_file
 
     # Convert all of the rasters inside the SVG file with 80% compressed WEBP
@@ -114,10 +113,8 @@ def as_svg(image, filename='temp.svg', compress=True, force=False):
                     with open(png_tmp, 'wb') as fp_png:
                         fp_png.write(bobj)
                     cwebp_out = op.join(tmp_dir, "cwebp_out.webp")
-                    subprocess.check_call(["cwebp", "-noalpha", png_tmp, "-q",
-                                             "80", "-o", cwebp_out],
-                                          shell=True,
-                                          stdout=subprocess.DEVNULL)
+                    subprocess.check_call("cwebp -quiet -noalpha -q 80 %s -o %s"%(png_tmp, cwebp_out),
+                                          shell=True)
                     with open(cwebp_out, 'rb') as fp_webp:
                         webp_b64 = base64.b64encode(fp_webp.read()).decode(
                             "utf-8")


### PR DESCRIPTION
This adds two-fold compression to SVG reportlets:

- paths in SVG are optimized using `svgo`
- bitmaps are converted to webp and compressed at 80%

The compression is only performed if the necessary tools are present.