### PR TITLE
ReconAll report

### DIFF
--- a/niworkflows/common/report.py
+++ b/niworkflows/common/report.py
@@ -23,6 +23,8 @@ class ReportCapableInputSpec(BaseInterfaceInputSpec):
         False, usedefault=True, desc="Set to true to enable report generation for node")
     out_report = File(
         'report.html', usedefault=True, desc='filename for the visual report')
+    mock_run = traits.Bool(False, usedefault=True,
+                           desc="Set to true to skip running the base interface")
 
 
 class ReportCapableOutputSpec(TraitedSpec):
@@ -40,11 +42,14 @@ class ReportCapableInterface(BaseInterface):
     def _run_interface(self, runtime):
         """ delegates to base interface run method, then attempts to generate reports """
 
-        try:
-            runtime = super(
-                ReportCapableInterface, self)._run_interface(runtime)
-        except NotImplementedError:
-            pass  # the interface is derived from BaseInterface
+        if not self.inputs.mock_run:
+            try:
+                runtime = super(
+                    ReportCapableInterface, self)._run_interface(runtime)
+            except NotImplementedError:
+                pass  # the interface is derived from BaseInterface
+        else:
+            runtime.returncode = 0
 
         # leave early if there's nothing to do
         if not self.inputs.generate_report:
@@ -177,4 +182,45 @@ class SegmentationRC(ReportCapableInterface):
             out_file=self.inputs.out_report,
             masked=self._masked,
             title=self._report_title
+        )
+
+
+class SurfaceSegmentationRC(ReportCapableInterface):
+
+    """ An abstract mixin to registration nipype interfaces """
+
+    def __init__(self, **inputs):
+        self._anat_file = None
+        self._mask_file = None
+        self._contour = None
+        super(SurfaceSegmentationRC, self).__init__(**inputs)
+
+    def _generate_report(self):
+        """ Generates the visual report """
+        from niworkflows.viz.utils import compose_view, plot_registration
+        NIWORKFLOWS_LOG.info('Generating visual report')
+
+        anat = load_img(self._anat_file)
+        contour_nii = load_img(self._contour) if self._contour is not None else None
+
+        if self._mask_file:
+            anat = unmask(apply_mask(anat, self._mask_file), self._mask_file)
+            mask_nii = load_img(self._mask_file)
+        else:
+            mask_nii = threshold_img(anat, 1e-3)
+
+        n_cuts = 7
+        if not self._mask_file and contour_nii:
+            cuts = cuts_from_bbox(contour_nii, cuts=n_cuts)
+        else:
+            cuts = cuts_from_bbox(mask_nii, cuts=n_cuts)
+
+        # Call composer
+        compose_view(
+            plot_registration(anat, 'fixed-image',
+                              estimate_brightness=True,
+                              cuts=cuts,
+                              contour=contour_nii),
+            [],
+            out_file=self._out_report
         )

--- a/niworkflows/common/report.py
+++ b/niworkflows/common/report.py
@@ -23,8 +23,6 @@ class ReportCapableInputSpec(BaseInterfaceInputSpec):
         False, usedefault=True, desc="Set to true to enable report generation for node")
     out_report = File(
         'report.html', usedefault=True, desc='filename for the visual report')
-    mock_run = traits.Bool(False, usedefault=True,
-                           desc="Set to true to skip running the base interface")
 
 
 class ReportCapableOutputSpec(TraitedSpec):
@@ -37,12 +35,13 @@ class ReportCapableInterface(BaseInterface):
 
     def __init__(self, **inputs):
         self._out_report = None
+        self._mock_run = None
         super(ReportCapableInterface, self).__init__(**inputs)
 
     def _run_interface(self, runtime):
         """ delegates to base interface run method, then attempts to generate reports """
 
-        if not self.inputs.mock_run:
+        if not self._mock_run:
             try:
                 runtime = super(
                     ReportCapableInterface, self)._run_interface(runtime)
@@ -105,6 +104,14 @@ class ReportCapableInterface(BaseInterface):
         errorstr += '</div>\n'
         with open(self._out_report, 'w' if PY3 else 'wb') as outfile:
             outfile.write(errorstr)
+
+    @property
+    def mock_run(self):
+        return self._mock_run
+
+    @mock_run.setter
+    def mock_run(self, value):
+        self._mock_run = value
 
 
 class RegistrationRCInputSpec(ReportCapableInputSpec):

--- a/niworkflows/tests/test_reports.py
+++ b/niworkflows/tests/test_reports.py
@@ -17,7 +17,7 @@ from niworkflows.data.getters import (get_mni_template_ras, get_ds003_downsample
 
 from niworkflows.interfaces.registration import (
     FLIRTRPT, RobustMNINormalizationRPT, ANTSRegistrationRPT, BBRegisterRPT)
-from niworkflows.interfaces.segmentation import FASTRPT
+from niworkflows.interfaces.segmentation import FASTRPT, ReconAllRPT
 from niworkflows.interfaces.masks import BETRPT, BrainExtractionRPT
 
 MNI_DIR = get_mni_template_ras()
@@ -160,3 +160,12 @@ class TestFASTRPT(unittest.TestCase):
                                    probability_maps=True, out_basename='test')
 
         _smoke_test_report(report_interface, 'testFAST_no_segments.html')
+
+
+class TestReconAllRPT(unittest.TestCase):
+    def test_generate_report(self):
+        report_interface = ReconAllRPT(subject_id='fsaverage', directive='all',
+                                       subjects_dir=os.getenv('SUBJECTS_DIR'),
+                                       mock_run=True, generate_report=True,
+                                       out_report='test.svg')
+        _smoke_test_report(report_interface, 'testReconAll.svg')

--- a/niworkflows/tests/test_reports.py
+++ b/niworkflows/tests/test_reports.py
@@ -166,6 +166,7 @@ class TestReconAllRPT(unittest.TestCase):
     def test_generate_report(self):
         report_interface = ReconAllRPT(subject_id='fsaverage', directive='all',
                                        subjects_dir=os.getenv('SUBJECTS_DIR'),
-                                       mock_run=True, generate_report=True,
+                                       generate_report=True,
                                        out_report='test.svg')
+        report_interface.mock_run = True
         _smoke_test_report(report_interface, 'testReconAll.svg')


### PR DESCRIPTION
As discussed in #102, shows white/pial surfaces overlaid on masked T1.

`SurfaceSegmentationRC` is derived more from `RegistrationRC` with the "moving" image removed, as FreeSurfer doesn't have quite the equivalents of FAST's 3-class output files... `aseg.mgz` could be used, but it has many subcortical divisions, which would need to be mapped into white, gray, and possibly CSF.

As recon-all is very long to run, report interfaces are extended to allow mock runs, which assumes necessary files have already been created. At present, I believe this requires that the necessary files can be derived from the InputSpec, as the OutputSpec shouldn't be properly instantiated.

Closes #102.