### PR TITLE
[RTM] Typo fixed in nipype

### DIFF
--- a/niworkflows/info.py
+++ b/niworkflows/info.py
@@ -49,7 +49,7 @@ CLASSIFIERS = [
     'Programming Language :: Python :: 3.5',
 ]
 
-REQUIRES = ['nipype>=0.13.0rc1', 'future', 'nilearn>=0.2.6', 'sklearn', 'pandas', 'matplotlib',
+REQUIRES = ['nipype', 'future', 'nilearn>=0.2.6', 'sklearn', 'pandas', 'matplotlib',
             'jinja2', 'svgutils', 'tinycss']
 SETUP_REQUIRES = []
 REQUIRES += SETUP_REQUIRES

--- a/niworkflows/interfaces/segmentation.py
+++ b/niworkflows/interfaces/segmentation.py
@@ -52,9 +52,7 @@ class ReconAllInputSpecRPT(nrc.ReportCapableInputSpec,
     pass
 
 class ReconAllOutputSpecRPT(nrc.ReportCapableOutputSpec,
-                            freesurfer.preprocess.ReconAllIOutputSpec):
-    # Note typo in fsl.preprocess.ReconAllIOutputSpec.
-    # Can fix when the pinned nipype includes 36e6c17
+                            freesurfer.preprocess.ReconAllOutputSpec):
     pass
 
 class ReconAllRPT(nrc.SurfaceSegmentationRC, freesurfer.preprocess.ReconAll):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+-e git+https://github.com/nipy/nipype.git@61978ad#egg=nipype


### PR DESCRIPTION
nipy/nipype#1784 has been merged, so we can track nipype/master. Remove version constraint from `info.py`, to avoid overwriting pinned copy.

Precondition for poldracklab/fmriprep#347.