### PR TITLE
[RFC] Set default initialization selections for BBRegisterRPT

### DIFF
--- a/niworkflows/interfaces/registration.py
+++ b/niworkflows/interfaces/registration.py
@@ -156,7 +156,16 @@ class ApplyXFMRPT(FLIRTRPT, fsl.ApplyXFM):
 
 class BBRegisterInputSpecRPT(nrc.RegistrationRCInputSpec,
                              freesurfer.preprocess.BBRegisterInputSpec):
-    pass
+    if freesurfer.preprocess.FSVersion >= LooseVersion('6.0.0'):
+        init = traits.Enum(
+            'coreg', 'rr', 'spm', 'fsl', 'header', 'best',
+            argstr='--init-%s', usedefault=True, xor=['init_reg_file'],
+            desc='initialize registration with mri_coreg, spm, fsl, or header')
+    else:
+        init = traits.Enum(
+            'fsl', 'spm', 'header',
+            argstr='--init-%s', usedefault=True, xor=['init_reg_file'],
+            desc='initialize registration with fsl, spm, or header')
 
 class BBRegisterOutputSpecRPT(nrc.ReportCapableOutputSpec,
                               freesurfer.preprocess.BBRegisterOutputSpec):
@@ -177,5 +186,3 @@ class BBRegisterRPT(nrc.RegistrationRC, freesurfer.BBRegister):
         NIWORKFLOWS_LOG.info(
             'Report - setting fixed (%s) and moving (%s) images',
             self._fixed_image, self._moving_image)
-
-


### PR DESCRIPTION
FS6 has a new default initialization method for `bbregister` (`mri_coreg`). I've added an updated inputspec to Nipype with nipy/nipype#1811, but, as discussed Friday, I'm trying to avoid depending on unreleased Nipype features.

I'm proposing to use `--init-coreg` in FSv6.0, and `--init-fsl` in FSv5.3. By using a modified `init` trait in both cases, this allows `BBRegisterRPT` to be called without an explicit `init` parameter, in either case, which means the check doesn't need to be made at workflow creation.

What do people think about (a) the initialization choices; (b) the method for setting them?