### PR TITLE
BBRegisterRPT: Use inputs.subjects_dir to find structurals

### DIFF
--- a/niworkflows/interfaces/registration.py
+++ b/niworkflows/interfaces/registration.py
@@ -167,15 +167,11 @@ class BBRegisterRPT(nrc.RegistrationRC, freesurfer.BBRegister):
     output_spec = BBRegisterOutputSpecRPT
 
     def _post_run_hook(self, runtime):
-        # bbregister takes a subject_id, so the target is likely to be the
-        # T1 anatomical
-        mri_dir = os.path.join(os.getenv('SUBJECTS_DIR'),
-                               self.inputs.subject_id, 'mri')
-        self._fixed_image = os.path.join(mri_dir, 'T1.mgz')
+        mri_dir = os.path.join(self.inputs.subjects_dir, self.inputs.subject_id,
+                               'mri')
+        self._fixed_image = os.path.join(mri_dir, 'brainmask.mgz')
         self._moving_image = self.aggregate_outputs().registered_file
         self._contour = os.path.join(mri_dir, 'ribbon.mgz')
         NIWORKFLOWS_LOG.info(
             'Report - setting fixed (%s) and moving (%s) images',
             self._fixed_image, self._moving_image)
-
-


### PR DESCRIPTION
The reporting in `BBRegisterRPT` ignores `subjects_dir` when passed through nipype.

Also prefers `brainmask.mgz` to `T1.mgz`, to more closely resemble the output of `FLIRTRPT`.