### PR TITLE
Compress surface segmentation reports

### DIFF
--- a/niworkflows/common/report.py
+++ b/niworkflows/common/report.py
@@ -235,7 +235,8 @@ class SurfaceSegmentationRC(ReportCapableInterface):
             plot_registration(anat, 'fixed-image',
                               estimate_brightness=True,
                               cuts=cuts,
-                              contour=contour_nii),
+                              contour=contour_nii,
+                              compress=self.inputs.compress_report),
             [],
             out_file=self._out_report
         )


### PR DESCRIPTION
Should be an easy one. I'll check the artifacts and merge if the ReconAll output is compressed.

Fixes #132.