### PR TITLE
[RTM] Derive BBRegisterInputSpecRPT from BBRegisterInputSpec6

### DIFF
--- a/niworkflows/interfaces/registration.py
+++ b/niworkflows/interfaces/registration.py
@@ -155,7 +155,7 @@ class ApplyXFMRPT(FLIRTRPT, fsl.ApplyXFM):
 
 
 class BBRegisterInputSpecRPT(nrc.RegistrationRCInputSpec,
-                             freesurfer.preprocess.BBRegisterInputSpec):
+                             freesurfer.preprocess.BBRegisterInputSpec6):
     pass
 
 class BBRegisterOutputSpecRPT(nrc.ReportCapableOutputSpec,

--- a/niworkflows/interfaces/registration.py
+++ b/niworkflows/interfaces/registration.py
@@ -5,6 +5,7 @@ ReportCapableInterfaces for registration tools
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
 import os
+from distutils.version import LooseVersion
 
 from nipype.interfaces import fsl, ants, freesurfer
 from niworkflows.anat import mni
@@ -154,9 +155,15 @@ class ApplyXFMRPT(FLIRTRPT, fsl.ApplyXFM):
     output_spec = FLIRTOutputSpecRPT
 
 
-class BBRegisterInputSpecRPT(nrc.RegistrationRCInputSpec,
-                             freesurfer.preprocess.BBRegisterInputSpec6):
-    pass
+if LooseVersion(freesurfer.preprocess.FSVersion) < LooseVersion("6.0.0"):
+    class BBRegisterInputSpecRPT(nrc.RegistrationRCInputSpec,
+                                 freesurfer.preprocess.BBRegisterInputSpec):
+        pass
+else:
+    class BBRegisterInputSpecRPT(nrc.RegistrationRCInputSpec,
+                                 freesurfer.preprocess.BBRegisterInputSpec6):
+        pass
+
 
 class BBRegisterOutputSpecRPT(nrc.ReportCapableOutputSpec,
                               freesurfer.preprocess.BBRegisterOutputSpec):

--- a/niworkflows/interfaces/registration.py
+++ b/niworkflows/interfaces/registration.py
@@ -169,13 +169,14 @@ class BBRegisterOutputSpecRPT(nrc.ReportCapableOutputSpec,
                               freesurfer.preprocess.BBRegisterOutputSpec):
     pass
 
+
 class BBRegisterRPT(nrc.RegistrationRC, freesurfer.BBRegister):
     input_spec = BBRegisterInputSpecRPT
     output_spec = BBRegisterOutputSpecRPT
 
     def _post_run_hook(self, runtime):
-        mri_dir = os.path.join(self.inputs.subjects_dir, self.inputs.subject_id,
-                               'mri')
+        mri_dir = os.path.join(self.inputs.subjects_dir,
+                               self.inputs.subject_id, 'mri')
         self._fixed_image = os.path.join(mri_dir, 'brainmask.mgz')
         self._moving_image = self.aggregate_outputs().registered_file
         self._contour = os.path.join(mri_dir, 'ribbon.mgz')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
--e git+https://github.com/nipy/nipype.git@61978ad#egg=nipype
+-e git+https://github.com/nipy/nipype.git@661e6862d8ae7aa0173301870e207a68b3d683f5#egg=nipype


### PR DESCRIPTION
If we want to use `bbregister --init-coreg`, we need to derive the inputspec from `BBRegisterInputSpec6`.

If we want to support FS5.3 in niworkflows, I can run a version check for defining `BBRegisterInputSpecRPT`.