### PR TITLE
[ENH] Add a SimpleBeforeAfter report capable interface

### DIFF
--- a/.circle/pytests.sh
+++ b/.circle/pytests.sh
@@ -11,17 +11,17 @@ set -x         # Print command traces before executing command.
 code=0
 
 if [ "${CIRCLE_NODE_TOTAL:-1}" == "1" ]; then
-    docker run -ti -v /etc/localtime:/etc/localtime:ro --env SAVE_CIRCLE_ARTIFACTS="1" -v ${SCRATCH}/py3:/scratch -w /scratch --entrypoint=/usr/local/miniconda/bin/py.test niworkflows:py3 /root/niworkflows -n ${CIRCLE_NPROCS:-4} -v --junit-xml=/scratch/pytest.xml && \
-    docker run -ti -v /etc/localtime:/etc/localtime:ro --env SAVE_CIRCLE_ARTIFACTS="1" -v ${SCRATCH}/py2:/scratch -w /scratch --entrypoint=/usr/local/miniconda/bin/py.test niworkflows:py2 /root/niworkflows -n ${CIRCLE_NPROCS:-4} -v --junit-xml=/scratch/pytest.xml
+    docker run -ti -v /etc/localtime:/etc/localtime:ro --env SAVE_CIRCLE_ARTIFACTS="/scratch" -v ${SCRATCH}/py3:/scratch -w /scratch --entrypoint=/usr/local/miniconda/bin/py.test niworkflows:py3 /root/niworkflows -n ${CIRCLE_NPROCS:-4} -v --junit-xml=/scratch/pytest.xml && \
+    docker run -ti -v /etc/localtime:/etc/localtime:ro --env SAVE_CIRCLE_ARTIFACTS="/scratch" -v ${SCRATCH}/py2:/scratch -w /scratch --entrypoint=/usr/local/miniconda/bin/py.test niworkflows:py2 /root/niworkflows -n ${CIRCLE_NPROCS:-4} -v --junit-xml=/scratch/pytest.xml
     code=$(( $code + $? ))
 else
     case ${CIRCLE_NODE_INDEX} in
     0)
-        docker run -ti -v /etc/localtime:/etc/localtime:ro --env SAVE_CIRCLE_ARTIFACTS="1" -v ${SCRATCH}/py3:/scratch -w /scratch --entrypoint=/usr/local/miniconda/bin/py.test niworkflows:py3 /root/niworkflows -n ${CIRCLE_NPROCS:-4} -v --junit-xml=/scratch/pytest.xml
+        docker run -ti -v /etc/localtime:/etc/localtime:ro --env SAVE_CIRCLE_ARTIFACTS="/scratch" -v ${SCRATCH}/py3:/scratch -w /scratch --entrypoint=/usr/local/miniconda/bin/py.test niworkflows:py3 /root/niworkflows -n ${CIRCLE_NPROCS:-4} -v --junit-xml=/scratch/pytest.xml
         code=$(( $code + $? ))
         ;;
     1)
-        docker run -ti -v /etc/localtime:/etc/localtime:ro --env SAVE_CIRCLE_ARTIFACTS="1" -v ${SCRATCH}/py2:/scratch -w /scratch --entrypoint=/usr/local/miniconda/bin/py.test niworkflows:py2 /root/niworkflows -n ${CIRCLE_NPROCS:-4} -v --junit-xml=/scratch/pytest.xml
+        docker run -ti -v /etc/localtime:/etc/localtime:ro --env SAVE_CIRCLE_ARTIFACTS="/scratch" -v ${SCRATCH}/py2:/scratch -w /scratch --entrypoint=/usr/local/miniconda/bin/py.test niworkflows:py2 /root/niworkflows -n ${CIRCLE_NPROCS:-4} -v --junit-xml=/scratch/pytest.xml
         code=$(( $code + $? ))
         ;;
     esac

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+Version 0.0.7
+-------------
+
+* [ENH] Add a SimpleBeforeAfter report capable interface (#144)
+
 Version 0.0.6
 -------------
 

--- a/niworkflows/interfaces/__init__.py
+++ b/niworkflows/interfaces/__init__.py
@@ -7,4 +7,5 @@ from .registration import (FLIRTRPT as FLIRT,
                            ApplyXFMRPT as ApplyXFM,
                            RobustMNINormalizationRPT as RobustMNINormalization,
                            ANTSRegistrationRPT as Registration,
-                           ANTSApplyTransformsRPT as ApplyTransforms)
+                           ANTSApplyTransformsRPT as ApplyTransforms,
+                           SimpleBeforeAfterRPT as SimpleBeforeAfter)

--- a/niworkflows/interfaces/registration.py
+++ b/niworkflows/interfaces/registration.py
@@ -183,3 +183,36 @@ class BBRegisterRPT(nrc.RegistrationRC, freesurfer.BBRegister):
         NIWORKFLOWS_LOG.info(
             'Report - setting fixed (%s) and moving (%s) images',
             self._fixed_image, self._moving_image)
+
+
+class SimpleBeforeAfterInputSpecRPT(nrc.RegistrationRCInputSpec):
+    before = File(exists=True, mandatory=True, desc='file before')
+    after = File(exists=True, mandatory=True, desc='file after')
+    wm_seg = File(desc='reference white matter segmentation mask')
+
+
+class SimpleBeforeAfterOutputSpecRPT(nrc.ReportCapableOutputSpec):
+    pass
+
+class SimpleBeforeAfterRPT(nrc.RegistrationRC):
+    input_spec = SimpleBeforeAfterInputSpecRPT
+    output_spec = SimpleBeforeAfterOutputSpecRPT
+
+    def _run_interface(self, runtime):
+        """ there is not inner interface to run """
+        self._out_report = os.path.abspath(self.inputs.out_report)
+
+        self._fixed_image_label = "after"
+        self._moving_image_label = "before"
+        self._fixed_image = self.inputs.after
+        self._moving_image = self.inputs.before
+        self._contour = self.inputs.wm_seg if isdefined(self.inputs.wm_seg) else None
+        NIWORKFLOWS_LOG.info(
+            'Report - setting before (%s) and after (%s) images',
+            self._fixed_image, self._moving_image)
+
+        self._generate_report()
+        NIWORKFLOWS_LOG.info('Successfully created report (%s)', self._out_report)
+
+        return runtime
+

--- a/niworkflows/tests/test_reports.py
+++ b/niworkflows/tests/test_reports.py
@@ -31,8 +31,9 @@ def stage_artifacts(filename, new_filename):
     """ filename: the name of the file to be saved as an artifact.
         new_filename: what to call the artifact (which will be saved in the
        `/scratch` folder) """
-    if os.getenv('SAVE_CIRCLE_ARTIFACTS', False) == "1":
-        copy(filename, os.path.join('/scratch', new_filename))
+    save_artifacts = os.getenv('SAVE_CIRCLE_ARTIFACTS', False)
+    if save_artifacts:
+        copy(filename, os.path.join(save_artifacts, new_filename))
 
 def _smoke_test_report(report_interface, artifact_name):
     with InTemporaryDirectory():

--- a/niworkflows/tests/test_reports.py
+++ b/niworkflows/tests/test_reports.py
@@ -19,7 +19,7 @@ from niworkflows.data.getters import (get_mni_template_ras, get_ds003_downsample
 
 from niworkflows.interfaces.registration import (
     FLIRTRPT, RobustMNINormalizationRPT, ANTSRegistrationRPT, BBRegisterRPT,
-    ApplyXFMRPT)
+    ApplyXFMRPT, SimpleBeforeAfterRPT)
 from niworkflows.interfaces.segmentation import FASTRPT, ReconAllRPT
 from niworkflows.interfaces.masks import BETRPT, BrainExtractionRPT
 
@@ -69,6 +69,19 @@ class TestRegistrationInterfaces(unittest.TestCase):
             apply_xfm=True
         )
         _smoke_test_report(applyxfm_rpt, 'testApplyXFM.svg')
+
+
+    def test_SimpleBeforeAfterRPT(self):
+        """ the SimpleBeforeAfterRPT report capable test """
+        flirt_rpt = FLIRTRPT(generate_report=False, in_file=self.moving,
+                             reference=self.reference)
+
+        ba_rpt = SimpleBeforeAfterRPT(
+            generate_report=True,
+            before=self.reference,
+            after=flirt_rpt.run().outputs.out_file
+        )
+        _smoke_test_report(ba_rpt, 'test_SimpleBeforeAfterRPT.svg')
 
 
     def test_FLIRTRPT_w_BBR(self):


### PR DESCRIPTION
This interface generates a registration report with the
before and after labels using its `before` and `after` inputs.

It does not run any internal interface.

Use case:

Generate a report of the EPI before and after unwarping with the WM mask, so it is not necessary to clutter the EPI preprocessing workflow with the white matter input. It can be generated outside.