### PR TITLE
Move to fs.Info.looseversion() to check FreeSurfer version

### DIFF
--- a/niworkflows/interfaces/registration.py
+++ b/niworkflows/interfaces/registration.py
@@ -164,7 +164,7 @@ class ApplyXFMRPT(FLIRTRPT, fsl.ApplyXFM):
     output_spec = FLIRTOutputSpecRPT
 
 
-if LooseVersion("0") < LooseVersion(fs.preprocess.FSVersion) < LooseVersion("6.0.0"):
+if LooseVersion("0") < fs.Info.looseversion() < LooseVersion("6.0.0"):
     class BBRegisterInputSpecRPT(nrc.RegistrationRCInputSpec,
                                  fs.preprocess.BBRegisterInputSpec):
         pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
--e git+https://github.com/nipy/nipype.git@60142aeab82fe4ce00cd70295e814b7252b669bb#egg=nipype
+-e git+https://github.com/nipy/nipype.git@e1fb59500cb88c209976176bf4c0ef55ea4e25c2#egg=nipype

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
--e git+https://github.com/nipy/nipype.git@c15df990c1e0849aa789bc15aae286b0a6c16b6c#egg=nipype
+-e git+https://github.com/nipy/nipype.git@60142aeab82fe4ce00cd70295e814b7252b669bb#egg=nipype


### PR DESCRIPTION
This PR moves to a dependency on an updated version check. This would have broken things for people updating nipype since ~8am EDT today. This would not affect any Docker builds, due to the earlier requirement. FMRIPREP should be moved to this same nipype commit ASAP once this is merged.

Closes #151.