### PR TITLE
[RTM] Add SimpleInterface subclass of BaseInterface

### DIFF
--- a/niworkflows/interfaces/base.py
+++ b/niworkflows/interfaces/base.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
+# vi: set ft=python sts=4 ts=4 sw=4 et:
+from nipype.interfaces.base import BaseInterface
+
+
+class SimpleInterface(BaseInterface):
+    """ An interface pattern that allows outputs to be set in a dictionary """
+    def __init__(self, **inputs):
+        super(SimpleInterface, self).__init__(**inputs)
+        self._results = {}
+
+    def _list_outputs(self):
+        return self._results

--- a/niworkflows/interfaces/registration.py
+++ b/niworkflows/interfaces/registration.py
@@ -11,16 +11,15 @@ import nibabel as nb
 import numpy as np
 from nipype.algorithms.confounds import is_outlier
 
-from nipype.interfaces.base import (traits, isdefined, TraitedSpec, BaseInterface,
-                                    BaseInterfaceInputSpec, File, InputMultiPath,
-                                    OutputMultiPath)
+from nipype.interfaces.base import (traits, isdefined, TraitedSpec,
+                                    BaseInterfaceInputSpec, File)
+from .base import SimpleInterface
 
 from nipype.interfaces import freesurfer as fs
 from nipype.interfaces import fsl, ants, afni
 from niworkflows.anat import mni
 import niworkflows.common.report as nrc
 from niworkflows import NIWORKFLOWS_LOG
-from nipype.interfaces.base import isdefined, File
 from nilearn.image import index_img
 
 class RobustMNINormalizationInputSpecRPT(
@@ -239,7 +238,7 @@ class EstimateReferenceImageOutputSpec(TraitedSpec):
                                            "the input file")
 
 
-class EstimateReferenceImage(BaseInterface):
+class EstimateReferenceImage(SimpleInterface):
     """
     Given an 4D EPI file estimate an optimal reference image that could be later
     used for motion estimation and coregistration purposes. If detected uses
@@ -285,11 +284,7 @@ class EstimateReferenceImage(BaseInterface):
             nb.Nifti1Image(median_image_data, in_nii.affine,
                            in_nii.header).to_filename(out_ref_fname)
 
-        self._results = dict()
         self._results["ref_image"] = out_ref_fname
         self._results["n_volumes_to_discard"] = n_volumes_to_discard
 
         return runtime
-
-    def _list_outputs(self):
-        return self._results


### PR DESCRIPTION
This exists as both [`mriqc.interfaces.base.MRIQCBaseInterface`](https://github.com/poldracklab/mriqc/blob/master/mriqc/interfaces/base.py#L11) and [`fmriprep.interfaces.bids.SimpleInterface`](https://github.com/poldracklab/fmriprep/blob/master/fmriprep/interfaces/bids.py#L38).