### PR TITLE
ENH: Expose get_dataset and a template name-resource map

### DIFF
--- a/niworkflows/data/__init__.py
+++ b/niworkflows/data/__init__.py
@@ -15,4 +15,6 @@ from .getters import (get_brainweb_1mm_normal,
                       get_mni152_nlin_sym_las,
                       get_mni152_nlin_sym_ras,
                       get_mni_icbm152_linear,
-                      get_mni_icbm152_nlin_asym_09c)
+                      get_mni_icbm152_nlin_asym_09c,
+                      get_dataset,
+                      TEMPLATE_MAP)

--- a/niworkflows/data/getters.py
+++ b/niworkflows/data/getters.py
@@ -30,6 +30,11 @@ OSF_RESOURCES = {
     'mni_icbm152_nlin_asym_09c': ('580705089ad5a101f17944a9', '002f9bf24dc5c32de50c03f01fa539ec')
 }
 
+# Map names of templates to OSF_RESOURCES keys
+TEMPLATE_MAP = {
+    'MNI152NLin2009cAsym': 'mni_icbm152_nlin_asym_09c',
+}
+
 def get_dataset(dataset_name, data_dir=None, url=None, resume=True, verbose=1):
     """Download and load the BIDS-fied brainweb 1mm normal
 


### PR DESCRIPTION
This is intended to enable poldracklab/fmriprep#498. It enables selecting a data grabber by template name as used in fmriprep.