### PR TITLE
Dev version: Use last release + 0.0.1 + '-dev'

### DIFF
--- a/niworkflows/anat/mni.py
+++ b/niworkflows/anat/mni.py
@@ -8,6 +8,7 @@ from os import path as op
 import shutil
 import pkg_resources as pkgr
 from multiprocessing import cpu_count
+from distutils.version import LooseVersion
 
 from nipype.interfaces.ants.registration import Registration, RegistrationOutputSpec
 from nipype.interfaces.ants.resampling import ApplyTransforms
@@ -16,12 +17,18 @@ from nipype.interfaces.base import (traits, isdefined, BaseInterface, BaseInterf
                                     File, InputMultiPath)
 
 from niworkflows.data import getters
-from niworkflows import __packagename__, NIWORKFLOWS_LOG
+from niworkflows import __packagename__, NIWORKFLOWS_LOG, __version__
+
+niworkflows_version = LooseVersion(__version__)
+
 
 import nibabel as nb
 import numpy as np
 
 class RobustMNINormalizationInputSpec(BaseInterfaceInputSpec):
+    # Enable deprecation
+    package_version = niworkflows_version
+
     moving_image = File(exists=True, mandatory=True, desc='image to apply transformation to')
     reference_image = File(exists=True, desc='override the reference image')
     moving_mask = File(exists=True, desc='moving image mask')

--- a/niworkflows/anat/mni.py
+++ b/niworkflows/anat/mni.py
@@ -28,7 +28,7 @@ class RobustMNINormalizationInputSpec(BaseInterfaceInputSpec):
     reference_mask = File(exists=True, desc='reference image mask')
     num_threads = traits.Int(cpu_count(), usedefault=True, nohash=True,
                              desc="Number of ITK threads to use")
-    testing = traits.Bool(False, deprecated='99.99.99', desc='use testing settings')
+    testing = traits.Bool(False, deprecated='0.0.7', desc='use testing settings')
     flavor = traits.Enum('precise', 'testing', 'fast', usedefault=True,
                          desc='registration settings parameter set')
     orientation = traits.Enum('RAS', 'LAS', mandatory=True, usedefault=True,

--- a/niworkflows/anat/mni.py
+++ b/niworkflows/anat/mni.py
@@ -8,7 +8,7 @@ from os import path as op
 import shutil
 import pkg_resources as pkgr
 from multiprocessing import cpu_count
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 from nipype.interfaces.ants.registration import Registration, RegistrationOutputSpec
 from nipype.interfaces.ants.resampling import ApplyTransforms
@@ -19,7 +19,7 @@ from nipype.interfaces.base import (traits, isdefined, BaseInterface, BaseInterf
 from niworkflows.data import getters
 from niworkflows import __packagename__, NIWORKFLOWS_LOG, __version__
 
-niworkflows_version = LooseVersion(__version__)
+niworkflows_version = Version(__version__)
 
 
 import nibabel as nb

--- a/niworkflows/info.py
+++ b/niworkflows/info.py
@@ -11,7 +11,7 @@ as well as for open-source software distribution.
 from __future__ import absolute_import, division, print_function
 import datetime
 
-__version__ = '99.99.99'
+__version__ = '0.0.7-dev'
 __packagename__ = 'niworkflows'
 __author__ = 'The CRN developers'
 __copyright__ = 'Copyright {}, Center for Reproducible Neuroscience, Stanford University'.format(

--- a/niworkflows/info.py
+++ b/niworkflows/info.py
@@ -40,7 +40,7 @@ CLASSIFIERS = [
 ]
 
 REQUIRES = ['nipype', 'future', 'nilearn>=0.2.6', 'sklearn', 'pandas', 'matplotlib',
-            'jinja2', 'svgutils', 'tinycss']
+            'jinja2', 'svgutils', 'tinycss', 'packaging']
 SETUP_REQUIRES = []
 REQUIRES += SETUP_REQUIRES
 

--- a/niworkflows/tests/test_reports.py
+++ b/niworkflows/tests/test_reports.py
@@ -11,6 +11,7 @@ from shutil import copy
 
 import nibabel as nb
 from nilearn import image
+from traits.trait_errors import TraitError
 from nipype.utils.tmpdirs import InTemporaryDirectory
 
 
@@ -107,15 +108,26 @@ class TestRegistrationInterfaces(unittest.TestCase):
     def test_RobustMNINormalizationRPT(self):
         """ the RobustMNINormalizationRPT report capable test """
         ants_rpt = RobustMNINormalizationRPT(
-            generate_report=True, moving_image=self.moving, testing=True)
+            generate_report=True, moving_image=self.moving, flavor='testing')
         _smoke_test_report(ants_rpt, 'testRobustMNINormalizationRPT.svg')
 
     def test_RobustMNINormalizationRPT_masked(self):
         """ the RobustMNINormalizationRPT report capable test with masking """
         ants_rpt = RobustMNINormalizationRPT(
             generate_report=True, moving_image=self.moving,
-            reference_mask=self.reference_mask, testing=True)
+            reference_mask=self.reference_mask, flavor='testing')
         _smoke_test_report(ants_rpt, 'testRobustMNINormalizationRPT_masked.svg')
+
+    def test_RobustMNINormalizationRPT_deprecation(self):
+        try:
+            ants_rpt = RobustMNINormalizationRPT(
+                generate_report=True, moving_image=self.moving, testing=True)
+        except TraitError as e:
+            if 'deprecated' not in e.msg:
+                raise
+        else:
+            raise Exception('RobustMNINormalizationRPT not raising trait error for '
+                            'input trait "testing"')
 
     def test_ANTSRegistrationRPT(self):
         """ the RobustMNINormalizationRPT report capable test """

--- a/niworkflows/tests/test_reports.py
+++ b/niworkflows/tests/test_reports.py
@@ -8,11 +8,12 @@ import unittest
 import pkg_resources as pkgr
 from multiprocessing import cpu_count
 from shutil import copy
+import warnings
 
 import nibabel as nb
 from nilearn import image
-from traits.trait_errors import TraitError
 from nipype.utils.tmpdirs import InTemporaryDirectory
+from nibabel.testing import clear_and_catch_warnings
 
 
 from niworkflows.data.getters import (get_mni_template_ras, get_ds003_downsampled,
@@ -119,15 +120,12 @@ class TestRegistrationInterfaces(unittest.TestCase):
         _smoke_test_report(ants_rpt, 'testRobustMNINormalizationRPT_masked.svg')
 
     def test_RobustMNINormalizationRPT_deprecation(self):
-        try:
-            ants_rpt = RobustMNINormalizationRPT(
+        with clear_and_catch_warnings() as w:
+            warnings.simplefilter('always', UserWarning)
+            assert len(w) == 0
+            RobustMNINormalizationRPT(
                 generate_report=True, moving_image=self.moving, testing=True)
-        except TraitError as e:
-            if 'deprecated' not in e.msg:
-                raise
-        else:
-            raise Exception('RobustMNINormalizationRPT not raising trait error for '
-                            'input trait "testing"')
+            assert len(w) == 1
 
     def test_ANTSRegistrationRPT(self):
         """ the RobustMNINormalizationRPT report capable test """

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
--e git+https://github.com/nipy/nipype.git@cda3fdc3be231f2c9d7bdbdbadee472a0bad9e92#egg=nipype
+-e git+https://github.com/nipy/nipype.git@c13f967506aa426c63ad4131cf29b655f742649c#egg=nipype


### PR DESCRIPTION
This version will resolve to `< 0.0.7`, which allows us to use meaningful deprecation versions, as discussed in #157.

This approach maintains the ability for Circle to replace the version on release, as well as allows meaningful version comparisons for git repositories. The additional work of updating the dev version number occurs *after* the release, so there's no risk of this resulting in a need for a quick release cycle because we screwed up the version number.

@oesteban mentioned a new system he's using in MRIQC. I'm okay with switching to that if that seems like a better option.

Fixes #163