### PR TITLE
ENH: Import nipype as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "niworkflows/nipype"]
 	path = nipype
-	url = git@github.com:nipy/nipype.git
+	url = git@github.com:effigies/nipype.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "niworkflows/nipype"]
 	path = nipype
-	url = git@github.com:effigies/nipype.git
+	url = https://github.com/effigies/nipype.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "niworkflows/nipype"]
 	path = nipype
-	url = https://github.com/effigies/nipype.git
+	url = https://github.com/nipy/nipype.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "niworkflows/nipype"]
+	path = nipype
+	url = git@github.com:nipy/nipype.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,6 +66,7 @@ ENV CRN_SHARED_DATA /niworkflows_data
 
 WORKDIR /root/
 COPY . niworkflows/
+RUN cd niworkflows && git submodule update --init --recusrive
 RUN find /root/niworkflows/ -name "test*.py" -exec chmod a-x '{}' \;
 RUN cd niworkflows && \
     pip install -e .[all] && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,6 @@ ENV CRN_SHARED_DATA /niworkflows_data
 
 WORKDIR /root/
 COPY . niworkflows/
-RUN cd niworkflows && git submodule update --init --recusrive
 RUN find /root/niworkflows/ -name "test*.py" -exec chmod a-x '{}' \;
 RUN cd niworkflows && \
     pip install -e .[all] && \

--- a/circle.yml
+++ b/circle.yml
@@ -15,7 +15,8 @@ dependencies:
     - mkdir -p ~/data/ ~/docker ${CIRCLE_TEST_REPORTS}/py2 ${CIRCLE_TEST_REPORTS}/py3
     - mkdir -p $SCRATCH && sudo setfacl -d -m group:ubuntu:rwx $SCRATCH && sudo setfacl -m group:ubuntu:rwx $SCRATCH
     - mkdir -p $SCRATCH/py2 $SCRATCH/py3
-    - git submodule update --init --recursive
+    - git submodule init && (git submodule update || true)
+    - git submodule sync && git -C nipype fetch origin && git submodule update
   override:
     - if [[ -e ~/docker/image.tar ]]; then docker load -i ~/docker/image.tar; fi :
         timeout: 6000

--- a/circle.yml
+++ b/circle.yml
@@ -15,6 +15,7 @@ dependencies:
     - mkdir -p ~/data/ ~/docker ${CIRCLE_TEST_REPORTS}/py2 ${CIRCLE_TEST_REPORTS}/py3
     - mkdir -p $SCRATCH && sudo setfacl -d -m group:ubuntu:rwx $SCRATCH && sudo setfacl -m group:ubuntu:rwx $SCRATCH
     - mkdir -p $SCRATCH/py2 $SCRATCH/py3
+    - git submodule update --init --recursive
   override:
     - if [[ -e ~/docker/image.tar ]]; then docker load -i ~/docker/image.tar; fi :
         timeout: 6000

--- a/niworkflows/anat/mni.py
+++ b/niworkflows/anat/mni.py
@@ -10,20 +10,20 @@ import pkg_resources as pkgr
 from multiprocessing import cpu_count
 from packaging.version import Version
 
-from nipype.interfaces.ants.registration import Registration, RegistrationOutputSpec
-from nipype.interfaces.ants.resampling import ApplyTransforms
-from nipype.interfaces.ants import AffineInitializer
-from nipype.interfaces.base import (traits, isdefined, BaseInterface, BaseInterfaceInputSpec,
-                                    File, InputMultiPath)
+from niworkflows.nipype.interfaces.ants.registration import Registration, RegistrationOutputSpec
+from niworkflows.nipype.interfaces.ants.resampling import ApplyTransforms
+from niworkflows.nipype.interfaces.ants import AffineInitializer
+from niworkflows.nipype.interfaces.base import (
+    traits, isdefined, BaseInterface, BaseInterfaceInputSpec, File)
 
 from niworkflows.data import getters
-from niworkflows import __packagename__, NIWORKFLOWS_LOG, __version__
-
-niworkflows_version = Version(__version__)
-
+from niworkflows import NIWORKFLOWS_LOG, __version__
 
 import nibabel as nb
 import numpy as np
+
+niworkflows_version = Version(__version__)
+
 
 class RobustMNINormalizationInputSpec(BaseInterfaceInputSpec):
     # Enable deprecation

--- a/niworkflows/anat/skullstrip.py
+++ b/niworkflows/anat/skullstrip.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function, unicode_literals
-from nipype.interfaces import ants
-from nipype.interfaces import afni
-from nipype.interfaces import fsl
-from nipype.interfaces import utility as niu
-from nipype.pipeline import engine as pe
+from niworkflows.nipype.interfaces import ants
+from niworkflows.nipype.interfaces import afni
+from niworkflows.nipype.interfaces import fsl
+from niworkflows.nipype.interfaces import utility as niu
+from niworkflows.nipype.pipeline import engine as pe
 
 
 def afni_wf(name='AFNISkullStripWorkflow', unifize=False, n4_nthreads=1):

--- a/niworkflows/common/orient.py
+++ b/niworkflows/common/orient.py
@@ -5,9 +5,10 @@
 # @Last Modified time: 2016-11-30 16:25:44
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from nipype.pipeline import engine as pe
-from nipype.interfaces import utility as niu
-from nipype.interfaces import afni
+from niworkflows.nipype.pipeline import engine as pe
+from niworkflows.nipype.interfaces import utility as niu
+from niworkflows.nipype.interfaces import afni
+
 
 def reorient_wf(name='ReorientWorkflow'):
     """A workflow to reorient images to 'RPI' orientation"""

--- a/niworkflows/common/report.py
+++ b/niworkflows/common/report.py
@@ -8,7 +8,8 @@ from sys import version_info
 from abc import abstractmethod
 from io import open
 
-from nipype.interfaces.base import File, traits, BaseInterface, BaseInterfaceInputSpec, TraitedSpec
+from niworkflows.nipype.interfaces.base import (
+    File, traits, BaseInterface, BaseInterfaceInputSpec, TraitedSpec)
 from niworkflows import NIWORKFLOWS_LOG
 from nilearn.masking import apply_mask, unmask
 from nilearn.image import threshold_img, load_img

--- a/niworkflows/info.py
+++ b/niworkflows/info.py
@@ -10,6 +10,11 @@ as well as for open-source software distribution.
 """
 from __future__ import absolute_import, division, print_function
 import datetime
+from os import path as op
+import runpy
+
+nipype_info = runpy.run_path(op.join(op.abspath(op.dirname(__file__)),
+                                     'nipype', 'info.py'))
 
 __version__ = '0.0.8-dev'
 __packagename__ = 'niworkflows'
@@ -39,8 +44,9 @@ CLASSIFIERS = [
     'Programming Language :: Python :: 3.5',
 ]
 
-REQUIRES = ['future', 'nilearn>=0.2.6', 'sklearn', 'pandas', 'matplotlib',
-            'jinja2', 'svgutils', 'tinycss', 'packaging']
+REQUIRES = nipype_info['REQUIRES'] + [
+    'nilearn>=0.2.6', 'sklearn', 'pandas', 'matplotlib', 'jinja2', 'svgutils',
+    'tinycss']
 SETUP_REQUIRES = []
 REQUIRES += SETUP_REQUIRES
 

--- a/niworkflows/info.py
+++ b/niworkflows/info.py
@@ -39,7 +39,7 @@ CLASSIFIERS = [
     'Programming Language :: Python :: 3.5',
 ]
 
-REQUIRES = ['nipype', 'future', 'nilearn>=0.2.6', 'sklearn', 'pandas', 'matplotlib',
+REQUIRES = ['future', 'nilearn>=0.2.6', 'sklearn', 'pandas', 'matplotlib',
             'jinja2', 'svgutils', 'tinycss', 'packaging']
 SETUP_REQUIRES = []
 REQUIRES += SETUP_REQUIRES

--- a/niworkflows/interfaces/base.py
+++ b/niworkflows/interfaces/base.py
@@ -2,7 +2,9 @@
 # -*- coding: utf-8 -*-
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
-from nipype.interfaces.base import BaseInterface
+from __future__ import absolute_import, unicode_literals
+
+from niworkflows.nipype.interfaces.base import BaseInterface
 
 
 class SimpleInterface(BaseInterface):

--- a/niworkflows/interfaces/masks.py
+++ b/niworkflows/interfaces/masks.py
@@ -7,10 +7,10 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import os
 
-from nilearn.image import mean_img
-from nipype.interfaces import fsl, ants
-from nipype.interfaces.base import File, BaseInterfaceInputSpec, traits, isdefined
-from nipype.algorithms import confounds
+from niworkflows.nipype.interfaces import fsl, ants
+from niworkflows.nipype.interfaces.base import (
+    File, BaseInterfaceInputSpec, traits, isdefined)
+from niworkflows.nipype.algorithms import confounds
 from niworkflows.common import report as nrc
 from niworkflows import NIWORKFLOWS_LOG
 from nilearn.masking import compute_epi_mask

--- a/niworkflows/interfaces/registration.py
+++ b/niworkflows/interfaces/registration.py
@@ -10,15 +10,15 @@ from distutils.version import LooseVersion
 import nibabel as nb
 import numpy as np
 from nilearn import image as nli
-from nipype.algorithms.confounds import is_outlier
-from nipype.utils.filemanip import fname_presuffix
+from niworkflows.nipype.algorithms.confounds import is_outlier
+from niworkflows.nipype.utils.filemanip import fname_presuffix
 
-from nipype.interfaces.base import (traits, isdefined, TraitedSpec,
-                                    BaseInterfaceInputSpec, File)
+from niworkflows.nipype.interfaces.base import (
+    traits, isdefined, TraitedSpec, BaseInterfaceInputSpec, File)
 from .base import SimpleInterface
 
-from nipype.interfaces import freesurfer as fs
-from nipype.interfaces import fsl, ants, afni
+from niworkflows.nipype.interfaces import freesurfer as fs
+from niworkflows.nipype.interfaces import fsl, ants, afni
 from niworkflows.anat import mni
 import niworkflows.common.report as nrc
 from niworkflows import NIWORKFLOWS_LOG

--- a/niworkflows/interfaces/segmentation.py
+++ b/niworkflows/interfaces/segmentation.py
@@ -7,8 +7,8 @@ ReportCapableInterfaces for segmentation tools
 from __future__ import absolute_import, division, print_function, unicode_literals
 import os
 
-from nipype.interfaces.base import File
-from nipype.interfaces import fsl, freesurfer
+from niworkflows.nipype.interfaces.base import File
+from niworkflows.nipype.interfaces import fsl, freesurfer
 from niworkflows.common import report as nrc
 from niworkflows import NIWORKFLOWS_LOG
 

--- a/niworkflows/interfaces/utils.py
+++ b/niworkflows/interfaces/utils.py
@@ -6,11 +6,13 @@
 Utilities
 
 """
+from __future__ import absolute_import, unicode_literals
 
 import nibabel as nb
-from nipype.utils.filemanip import fname_presuffix
-from nipype.interfaces.base import File, BaseInterfaceInputSpec, TraitedSpec
+from niworkflows.nipype.utils.filemanip import fname_presuffix
+from niworkflows.nipype.interfaces.base import File, BaseInterfaceInputSpec, TraitedSpec
 from .base import SimpleInterface
+
 
 class CopyHeaderInputSpec(BaseInterfaceInputSpec):
     in_file = File(exists=True, mandatory=True, desc='the file we get the data from')

--- a/niworkflows/nipype
+++ b/niworkflows/nipype
@@ -1,0 +1,1 @@
+../nipype/nipype

--- a/niworkflows/tests/test_reports.py
+++ b/niworkflows/tests/test_reports.py
@@ -8,13 +8,10 @@ import unittest
 import pkg_resources as pkgr
 from multiprocessing import cpu_count
 from shutil import copy
-import warnings
 
 import nibabel as nb
 from nilearn import image
-from nipype.utils.tmpdirs import InTemporaryDirectory
-from nibabel.testing import clear_and_catch_warnings
-
+from niworkflows.nipype.utils.tmpdirs import InTemporaryDirectory
 
 from niworkflows.data.getters import (get_mni_template_ras, get_ds003_downsampled,
                                       get_ants_oasis_template_ras)
@@ -30,6 +27,7 @@ MNI_DIR = get_mni_template_ras()
 MNI_2MM = os.path.join(MNI_DIR, 'MNI152_T1_2mm.nii.gz')
 DS003_DIR = get_ds003_downsampled()
 
+
 def stage_artifacts(filename, new_filename):
     """ filename: the name of the file to be saved as an artifact.
         new_filename: what to call the artifact (which will be saved in the
@@ -37,6 +35,7 @@ def stage_artifacts(filename, new_filename):
     save_artifacts = os.getenv('SAVE_CIRCLE_ARTIFACTS', False)
     if save_artifacts:
         copy(filename, os.path.join(save_artifacts, new_filename))
+
 
 def _smoke_test_report(report_interface, artifact_name):
     with InTemporaryDirectory():

--- a/niworkflows/viz/utils.py
+++ b/niworkflows/viz/utils.py
@@ -18,10 +18,10 @@ from pkg_resources import resource_filename as pkgrf
 from lxml import etree
 from nilearn import image as nlimage
 from nilearn.plotting import plot_anat
-from nipype.utils import filemanip
 
 from niworkflows import NIWORKFLOWS_LOG
 from niworkflows.viz.validators import HTMLValidator
+from niworkflows.nipype.utils import filemanip
 
 
 try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
--e git+https://github.com/nipy/nipype.git@603f424a379767abffa055283b799d69b840a58d#egg=nipype

--- a/setup.py
+++ b/setup.py
@@ -7,25 +7,15 @@
 
 PACKAGE_NAME = 'niworkflows'
 
+
 def main():
     """ Install entry-point """
     from os import path as op
-    from glob import glob
-    from inspect import getfile, currentframe
     from setuptools import setup, find_packages
-    from io import open  # pylint: disable=W0622
+    import runpy
 
-    this_path = op.dirname(op.abspath(getfile(currentframe())))
-
-    # Python 3: use a locals dictionary
-    # http://stackoverflow.com/a/1463370/6820620
-    ldict = locals()
-
-    # Get version and release info, which is all stored in niworkflows/info.py
-    module_file = op.join(this_path, PACKAGE_NAME, 'info.py')
-    with open(module_file) as infofile:
-        pythoncode = [line for line in infofile.readlines() if not line.strip().startswith('#')]
-        exec('\n'.join(pythoncode), globals(), ldict)
+    ldict = runpy.run_path(op.join(op.abspath(op.dirname(__file__)),
+                                   'niworkflows', 'info.py'))
 
     setup(
         name=PACKAGE_NAME,

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,9 @@ def main():
         tests_require=ldict['TESTS_REQUIRES'],
         extras_require=ldict['EXTRA_REQUIRES'],
         # Data
-        package_data={'niworkflows': ['data/t1-mni_registration*.json', 'viz/*.tpl']},
+        package_data={'niworkflows': ['data/t1-mni_registration*.json', 'viz/*.tpl',
+                                      'nipype/pipeline/engine/report_template.html',
+                                      'nipype/external/d3.js']},
         include_package_data=True,
     )
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,2 @@
+[pytest]
+norecursedirs = nipype


### PR DESCRIPTION
First pass at resolving poldracklab/fmriprep#541.

This approach makes a submodule in the root directory and symlinks `niworkflows/nipype` to `../nipype/nipype`. From a little bit of research, the alternative seemed to involve keeping an actual copy of `nipype/nipype` in the source tree, using either `git subtree` or `git filter-branch`. I'm not entirely clear on the details of these approaches, so it's possible that this isn't actually the simplest method.