### PR TITLE
Update CHANGES.rst

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+Version 0.1.0
+-------------
+
+* [ENH] Improve dependency management for users unable to use Docker/Singularity containers (#174)
+* [DEP] Removed RobustMNINormalization `testing` input; use `flavor='testing'` instead (#172)
+
 Version 0.0.7
 -------------
 


### PR DESCRIPTION
Suggesting bumping all the way up to 0.1.0 version since the submodule change is a fairly significant change in how dependent packages will access nipype.