### PR TITLE
FIX: Pass runtime to aggregate_outputs

### DIFF
--- a/niworkflows/interfaces/masks.py
+++ b/niworkflows/interfaces/masks.py
@@ -42,7 +42,7 @@ class BETRPT(nrc.SegmentationRC, fsl.BET):
         volume of in_file, with the resulting binary brain mask overlaid '''
 
         self._anat_file = self.inputs.in_file
-        self._mask_file = self.aggregate_outputs().mask_file
+        self._mask_file = self.aggregate_outputs(runtime=runtime).mask_file
         self._seg_files = [self._mask_file]
         self._masked = self.inputs.mask
         self._report_title = "BET: brain mask over anatomical input"
@@ -66,10 +66,10 @@ class BrainExtractionRPT(nrc.SegmentationRC, ants.segmentation.BrainExtraction):
     def _post_run_hook(self, runtime):
         ''' generates a report showing slices from each axis '''
 
-        brain_extraction_mask = self.aggregate_outputs().BrainExtractionMask
+        brain_extraction_mask = self.aggregate_outputs(runtime=runtime).BrainExtractionMask
 
         if isdefined(self.inputs.keep_temporary_files) and self.inputs.keep_temporary_files == 1:
-            self._anat_file = self.aggregate_outputs().N4Corrected0
+            self._anat_file = self.aggregate_outputs(runtime=runtime).N4Corrected0
         else:
             self._anat_file = self.inputs.anatomical_image
         self._mask_file = brain_extraction_mask
@@ -140,7 +140,7 @@ class ComputeEPIMask(nrc.SegmentationRC):
         volume of in_file, with the resulting binary brain mask overlaid '''
 
         self._anat_file = self.inputs.in_file
-        self._mask_file = self.aggregate_outputs().mask_file
+        self._mask_file = self.aggregate_outputs(runtime=runtime).mask_file
         self._seg_files = [self._mask_file]
         self._masked = True
         self._report_title = "nilearn.compute_epi_mask: brain mask over EPI input"
@@ -191,7 +191,7 @@ class TCompCorRPT(nrc.SegmentationRC, confounds.TCompCor):
     def _post_run_hook(self, runtime):
         ''' generates a report showing slices from each axis '''
 
-        high_variance_masks = self.aggregate_outputs().high_variance_masks
+        high_variance_masks = self.aggregate_outputs(runtime=runtime).high_variance_masks
 
         assert not isinstance(high_variance_masks, list),\
             "TCompCorRPT only supports a single output high variance mask. " \
@@ -204,7 +204,7 @@ class TCompCorRPT(nrc.SegmentationRC, confounds.TCompCor):
 
         NIWORKFLOWS_LOG.info('Generating report for tCompCor. file "%s", mask "%s"',
                              self.inputs.realigned_file,
-                             self.aggregate_outputs().high_variance_masks)
+                             self.aggregate_outputs(runtime=runtime).high_variance_masks)
 
 
 class SimpleShowMaskInputSpec(nrc.ReportCapableInputSpec):

--- a/niworkflows/interfaces/registration.py
+++ b/niworkflows/interfaces/registration.py
@@ -42,7 +42,7 @@ class RobustMNINormalizationRPT(
         self._fixed_image = self.norm.inputs.fixed_image[0]  # and get first item
         if isdefined(self.norm.inputs.fixed_image_mask):
             self._fixed_image_mask = self.norm.inputs.fixed_image_mask
-        self._moving_image = self.aggregate_outputs().warped_image
+        self._moving_image = self.aggregate_outputs(runtime=runtime).warped_image
         NIWORKFLOWS_LOG.info('Report - setting fixed (%s) and moving (%s) images',
                              self._fixed_image, self._moving_image)
 
@@ -61,7 +61,7 @@ class ANTSRegistrationRPT(nrc.RegistrationRC, ants.Registration):
 
     def _post_run_hook(self, runtime):
         self._fixed_image = self.inputs.fixed_image[0]
-        self._moving_image = self.aggregate_outputs().warped_image
+        self._moving_image = self.aggregate_outputs(runtime=runtime).warped_image
         NIWORKFLOWS_LOG.info('Report - setting fixed (%s) and moving (%s) images',
                              self._fixed_image, self._moving_image)
 
@@ -80,7 +80,7 @@ class ANTSApplyTransformsRPT(nrc.RegistrationRC, ants.ApplyTransforms):
 
     def _post_run_hook(self, runtime):
         self._fixed_image = self.inputs.reference_image
-        self._moving_image = self.aggregate_outputs().output_image
+        self._moving_image = self.aggregate_outputs(runtime=runtime).output_image
         NIWORKFLOWS_LOG.info('Report - setting fixed (%s) and moving (%s) images',
                              self._fixed_image, self._moving_image)
 
@@ -103,7 +103,7 @@ class ApplyTOPUPRPT(nrc.RegistrationRC, fsl.ApplyTOPUP):
     def _post_run_hook(self, runtime):
         self._fixed_image_label = "after"
         self._moving_image_label = "before"
-        self._fixed_image = index_img(self.aggregate_outputs().out_corrected, 0)
+        self._fixed_image = index_img(self.aggregate_outputs(runtime=runtime).out_corrected, 0)
         self._moving_image = index_img(self.inputs.in_files[0], 0)
         self._contour = self.inputs.wm_seg if isdefined(self.inputs.wm_seg) else None
         NIWORKFLOWS_LOG.info('Report - setting corrected (%s) and warped (%s) images',
@@ -127,7 +127,7 @@ class FUGUERPT(nrc.RegistrationRC, fsl.FUGUE):
     def _post_run_hook(self, runtime):
         self._fixed_image_label = "after"
         self._moving_image_label = "before"
-        self._fixed_image = self.aggregate_outputs().unwarped_file
+        self._fixed_image = self.aggregate_outputs(runtime=runtime).unwarped_file
         self._moving_image = self.inputs.in_file
         self._contour = self.inputs.wm_seg if isdefined(self.inputs.wm_seg) else None
         NIWORKFLOWS_LOG.info(
@@ -149,7 +149,7 @@ class FLIRTRPT(nrc.RegistrationRC, fsl.FLIRT):
 
     def _post_run_hook(self, runtime):
         self._fixed_image = self.inputs.reference
-        self._moving_image = self.aggregate_outputs().out_file
+        self._moving_image = self.aggregate_outputs(runtime=runtime).out_file
         self._contour = self.inputs.wm_seg if isdefined(self.inputs.wm_seg) else None
         NIWORKFLOWS_LOG.info(
             'Report - setting fixed (%s) and moving (%s) images',
@@ -188,7 +188,7 @@ class BBRegisterRPT(nrc.RegistrationRC, fs.BBRegister):
         mri_dir = os.path.join(self.inputs.subjects_dir,
                                self.inputs.subject_id, 'mri')
         self._fixed_image = os.path.join(mri_dir, 'brainmask.mgz')
-        self._moving_image = self.aggregate_outputs().registered_file
+        self._moving_image = self.aggregate_outputs(runtime=runtime).registered_file
         self._contour = os.path.join(mri_dir, 'ribbon.mgz')
         NIWORKFLOWS_LOG.info(
             'Report - setting fixed (%s) and moving (%s) images',

--- a/niworkflows/interfaces/segmentation.py
+++ b/niworkflows/interfaces/segmentation.py
@@ -36,18 +36,18 @@ class FASTRPT(nrc.SegmentationRC,
         arbitrary volume of `in_files`, with the resulting segmentation
         overlaid '''
         self._anat_file = self.inputs.in_files[0],
-        self._mask_file = self.aggregate_outputs().tissue_class_map
+        self._mask_file = self.aggregate_outputs(runtime=runtime).tissue_class_map
         # We are skipping the CSF class because with combination with others
         # it only shows the skullstriping mask
-        self._seg_files = self.aggregate_outputs().tissue_class_files[1:]
+        self._seg_files = self.aggregate_outputs(runtime=runtime).tissue_class_files[1:]
         self._masked = False
         self._report_title = "FAST: segmentation over anatomical"
 
         NIWORKFLOWS_LOG.info('Generating report for FAST (in_files %s, '
                              'segmentation %s, individual tissue classes %s).',
                              self.inputs.in_files,
-                             self.aggregate_outputs().tissue_class_map,
-                             self.aggregate_outputs().tissue_class_files)
+                             self.aggregate_outputs(runtime=runtime).tissue_class_map,
+                             self.aggregate_outputs(runtime=runtime).tissue_class_files)
 
 
 class ReconAllInputSpecRPT(nrc.ReportCapableInputSpec,
@@ -66,7 +66,7 @@ class ReconAllRPT(nrc.SurfaceSegmentationRC, freesurfer.preprocess.ReconAll):
         ''' generates a report showing nine slices, three per axis, of an
         arbitrary volume of `in_files`, with the resulting segmentation
         overlaid '''
-        outputs = self.aggregate_outputs()
+        outputs = self.aggregate_outputs(runtime=runtime)
         self._anat_file = os.path.join(outputs.subjects_dir,
                                        outputs.subject_id,
                                        'mri', 'brain.mgz')
@@ -111,7 +111,7 @@ class MELODICRPT(nrc.ReportCapableInterface, fsl.MELODIC):
         ''' generates a report showing nine slices, three per axis, of an
         arbitrary volume of `in_files`, with the resulting segmentation
         overlaid '''
-        outputs = self.aggregate_outputs()
+        outputs = self.aggregate_outputs(runtime=runtime)
         self._melodic_dir = outputs.out_dir
 
         NIWORKFLOWS_LOG.info('Generating report for MELODIC')


### PR DESCRIPTION
`FLIRT(save_log=True)` needs access to `runtime.stdout`. It seems like a good idea to pass `runtime` in all cases.