### PR TITLE
[ENH] Do not enforce float precision for ANTs

### DIFF
--- a/niworkflows/anat/mni.py
+++ b/niworkflows/anat/mni.py
@@ -57,6 +57,7 @@ class RobustMNINormalizationInputSpec(BaseInterfaceInputSpec):
                                         "Requires reliable and accurate masks."
                                         "See https://sourceforge.net/p/advants/discussion/840261/thread/27216e69/#c7ba")
     initial_moving_transform = File(exists=True, desc='transform for initialization')
+    float = traits.Bool(False, usedefault=True, desc='use single precision calculations')
 
 
 class RobustMNINormalization(BaseInterface):
@@ -139,6 +140,7 @@ class RobustMNINormalization(BaseInterface):
     def _get_ants_args(self):
         args = {'moving_image': self.inputs.moving_image,
                 'num_threads': self.inputs.num_threads,
+                'float': self.inputs.float,
                 'terminal_output': 'file',
                 'write_composite_transform': True,
                 'initial_moving_transform': self.inputs.initial_moving_transform}

--- a/niworkflows/data/epi-mni_registration_precise_000.json
+++ b/niworkflows/data/epi-mni_registration_precise_000.json
@@ -1,6 +1,5 @@
 {
     "dimension": 3,
-    "float": true,
     "convergence_threshold": [ 1e-06, 1e-06, 1e-06 ],
     "convergence_window_size": [ 20, 20, 10 ],
     "metric": [ "Mattes", "Mattes", "CC" ],

--- a/niworkflows/data/epi-mni_registration_precise_001.json
+++ b/niworkflows/data/epi-mni_registration_precise_001.json
@@ -1,6 +1,5 @@
 {
     "dimension": 3,
-    "float": true,
     "transforms": [ "Rigid", "Rigid", "Affine" ],
     "transform_parameters": [ [ 0.1 ], [ 0.01 ], [ 0.01 ] ],
     "metric": [ "Mattes", "Mattes", "Mattes" ],

--- a/niworkflows/data/epi-mni_registration_precise_002.json
+++ b/niworkflows/data/epi-mni_registration_precise_002.json
@@ -1,6 +1,5 @@
 {
     "dimension": 3,
-    "float": true,
     "convergence_threshold": [ 1e-06, 1e-06, 1e-06 ],
     "convergence_window_size": [ 20, 20, 5 ],
     "metric": [ "Mattes", "Mattes", "Mattes" ],

--- a/niworkflows/data/epi-mni_registration_testing_000.json
+++ b/niworkflows/data/epi-mni_registration_testing_000.json
@@ -1,6 +1,5 @@
 {
     "dimension": 3,
-    "float": true,
     "transforms": [ "Rigid", "Rigid", "Affine" ],
     "transform_parameters": [ [ 1.0 ], [ 1.0 ], [ 1.0 ] ],
     "metric": [ "Mattes", "Mattes", "Mattes" ],

--- a/niworkflows/data/epi-mni_registration_testing_001.json
+++ b/niworkflows/data/epi-mni_registration_testing_001.json
@@ -1,6 +1,5 @@
 {
     "dimension": 3,
-    "float": true,
     "transforms": [ "Rigid", "Rigid", "Affine" ],
     "transform_parameters": [ [ 1.0 ], [ 0.1 ], [ 0.1 ] ],
     "metric": [ "Mattes", "Mattes", "Mattes" ],

--- a/niworkflows/data/epi-mni_registration_testing_002.json
+++ b/niworkflows/data/epi-mni_registration_testing_002.json
@@ -1,6 +1,5 @@
 {
     "dimension": 3,
-    "float": true,
     "transforms": [ "Translation", "Rigid" ],
     "transform_parameters": [ [ 0.1 ], [ 0.01 ] ],
     "metric": [ "Mattes", "Mattes" ],

--- a/niworkflows/data/t1-mni_registration_fast_000.json
+++ b/niworkflows/data/t1-mni_registration_fast_000.json
@@ -1,6 +1,5 @@
 {
     "dimension": 3,
-    "float": true,
     "convergence_threshold": [ 1e-06, 1e-06, 1e-06 ],
     "convergence_window_size": [ 20, 20, 10 ],
     "metric": [ "Mattes", "Mattes", "Mattes" ],

--- a/niworkflows/data/t1-mni_registration_precise_000.json
+++ b/niworkflows/data/t1-mni_registration_precise_000.json
@@ -1,6 +1,5 @@
 {
     "dimension": 3,
-    "float": true,
     "convergence_threshold": [ 1e-06, 1e-06, 1e-06 ],
     "convergence_window_size": [ 20, 20, 10 ],
     "metric": [ "Mattes", "Mattes", "CC" ],

--- a/niworkflows/data/t1-mni_registration_precise_001.json
+++ b/niworkflows/data/t1-mni_registration_precise_001.json
@@ -1,6 +1,5 @@
 {
     "dimension": 3,
-    "float": true,
     "convergence_threshold": [ 1e-08, 1e-08, -0.01 ],
     "convergence_window_size": [ 20, 20, 5 ],
     "metric": [ "Mattes", "Mattes", [ "Mattes", "CC" ] ],

--- a/niworkflows/data/t1-mni_registration_precise_002.json
+++ b/niworkflows/data/t1-mni_registration_precise_002.json
@@ -1,6 +1,5 @@
 {
     "dimension": 3,
-    "float": true,
     "convergence_threshold": [ 1e-08, 1e-08, -0.01 ],
     "convergence_window_size": [ 20, 20, 5 ],
     "metric": [ "Mattes", "Mattes", [ "Mattes", "CC" ] ],

--- a/niworkflows/data/t1-mni_registration_testing_000.json
+++ b/niworkflows/data/t1-mni_registration_testing_000.json
@@ -15,7 +15,6 @@
     "shrink_factors": [[2], [1]],
     "winsorize_upper_quantile": 0.995,
     "winsorize_lower_quantile": 0.005,
-    "float": true,
     "use_estimate_learning_rate_once": [ true, true ],
     "use_histogram_matching": [ false, true ],
     "collapse_output_transforms": true,

--- a/niworkflows/data/t1-mni_registration_testing_001.json
+++ b/niworkflows/data/t1-mni_registration_testing_001.json
@@ -15,7 +15,6 @@
     "shrink_factors": [[2], [1]],
     "winsorize_upper_quantile": 0.995,
     "winsorize_lower_quantile": 0.005,
-    "float": true,
     "use_estimate_learning_rate_once": [ true, true ],
     "use_histogram_matching": [ false, true ],
     "collapse_output_transforms": true,

--- a/niworkflows/data/t1-mni_registration_testing_002.json
+++ b/niworkflows/data/t1-mni_registration_testing_002.json
@@ -15,7 +15,6 @@
     "shrink_factors": [[2], [1]],
     "winsorize_upper_quantile": 0.995,
     "winsorize_lower_quantile": 0.005,
-    "float": true,
     "use_estimate_learning_rate_once": [ true, true ],
     "use_histogram_matching": [ false, true ],
     "collapse_output_transforms": true,


### PR DESCRIPTION
This PR allows using ANTs' default (double precision) and also adds a `float` input in `RobustMNINormalization` to allow for changing it.