### PR TITLE
[RTM] ENH: Enable sbref to be passed to EstimateReferenceImage

### DIFF
--- a/niworkflows/interfaces/registration.py
+++ b/niworkflows/interfaces/registration.py
@@ -303,6 +303,7 @@ class ResampleBeforeAfterRPT(SimpleBeforeAfterRPT):
 
 class EstimateReferenceImageInputSpec(BaseInterfaceInputSpec):
     in_file = File(exists=True, mandatory=True, desc="4D EPI file")
+    sbref_file = File(exists=True, desc="Single band reference image")
     mc_method = traits.Enum("AFNI", "FSL", dsec="Which software to use to perform motion correction",
                             usedefault=True)
 
@@ -325,6 +326,10 @@ class EstimateReferenceImage(SimpleInterface):
     output_spec = EstimateReferenceImageOutputSpec
 
     def _run_interface(self, runtime):
+        if isdefined(self.inputs.sbref_file):
+            self._results['ref_image'] = self.inputs.sbref_file
+            return
+
         in_nii = nb.load(self.inputs.in_file)
         data_slice = in_nii.dataobj[:, :, :, :50]
         global_signal = data_slice.mean(axis=0).mean(
@@ -356,13 +361,12 @@ class EstimateReferenceImage(SimpleInterface):
             mc_slice_nii = nb.load(res.outputs.out_file)
 
             median_image_data = np.median(mc_slice_nii.get_data(), axis=3)
-            nb.Nifti1Image(median_image_data, in_nii.affine,
-                           in_nii.header).to_filename(out_ref_fname)
         else:
             median_image_data = np.median(
                 data_slice[:, :, :, :n_volumes_to_discard], axis=3)
-            nb.Nifti1Image(median_image_data, in_nii.affine,
-                           in_nii.header).to_filename(out_ref_fname)
+
+        nb.Nifti1Image(median_image_data, in_nii.affine,
+                       in_nii.header).to_filename(out_ref_fname)
 
         self._results["ref_image"] = out_ref_fname
         self._results["n_volumes_to_discard"] = n_volumes_to_discard


### PR DESCRIPTION
We've dropped single-band reference images from our fmriprep, but if there are cases where the sbref contrast is better than anything we can estimate, this may be useful.