### PR TITLE
RF: Use ReportCapableInterface from nipype

### DIFF
--- a/niworkflows/interfaces/masks.py
+++ b/niworkflows/interfaces/masks.py
@@ -37,7 +37,7 @@ class BETRPT(nrc.SegmentationRC, fsl.BET):
     output_spec = BETOutputSpecRPT
 
     def _run_interface(self, runtime):
-        if self.inputs.generate_report:
+        if self.generate_report:
             self.inputs.mask = True
 
         return super(BETRPT, self)._run_interface(runtime)
@@ -228,12 +228,14 @@ class TCompCorRPT(nrc.SegmentationRC, confounds.TCompCor):
 class SimpleShowMaskInputSpec(nrc.SVGReportCapableInputSpec):
     background_file = File(exists=True, mandatory=True, desc='file before')
     mask_file = File(exists=True, mandatory=True, desc='file before')
-    generate_report = traits.Bool(True, usedefault=True)
 
 
 class SimpleShowMaskRPT(nrc.SegmentationRC):
     input_spec = SimpleShowMaskInputSpec
     output_spec = reporting.ReportCapableOutputSpec
+
+    def __init__(self, generate_report=True, **kwargs):
+        super(SimpleShowMaskRPT, self).__init__(generate_report=generate_report, **kwargs)
 
     def _post_run_hook(self, runtime):
         self._anat_file = self.inputs.background_file

--- a/niworkflows/interfaces/masks.py
+++ b/niworkflows/interfaces/masks.py
@@ -17,16 +17,17 @@ from .. import NIWORKFLOWS_LOG
 from ..nipype.interfaces import fsl, ants
 from ..nipype.interfaces.base import (
     File, BaseInterfaceInputSpec, traits, isdefined, InputMultiPath, Str)
+from ..nipype.interfaces.mixins import reporting
 from ..nipype.algorithms import confounds
 from . import report_base as nrc
 
 
-class BETInputSpecRPT(nrc.ReportCapableInputSpec,
+class BETInputSpecRPT(nrc.SVGReportCapableInputSpec,
                       fsl.preprocess.BETInputSpec):
     pass
 
 
-class BETOutputSpecRPT(nrc.ReportCapableOutputSpec,
+class BETOutputSpecRPT(reporting.ReportCapableOutputSpec,
                        fsl.preprocess.BETOutputSpec):
     pass
 
@@ -53,13 +54,15 @@ class BETRPT(nrc.SegmentationRC, fsl.BET):
         NIWORKFLOWS_LOG.info('Generating report for BET. file "%s", and mask file "%s"',
                              self._anat_file, self._mask_file)
 
+        return super(BETRPT, self)._post_run_hook(runtime)
 
-class BrainExtractionInputSpecRPT(nrc.ReportCapableInputSpec,
+
+class BrainExtractionInputSpecRPT(nrc.SVGReportCapableInputSpec,
                                   ants.segmentation.BrainExtractionInputSpec):
     pass
 
 
-class BrainExtractionOutputSpecRPT(nrc.ReportCapableOutputSpec,
+class BrainExtractionOutputSpecRPT(reporting.ReportCapableOutputSpec,
                                    ants.segmentation.BrainExtractionOutputSpec):
     pass
 
@@ -84,15 +87,17 @@ class BrainExtractionRPT(nrc.SegmentationRC, ants.segmentation.BrainExtraction):
         NIWORKFLOWS_LOG.info('Generating report for ANTS BrainExtraction. file "%s", mask "%s"',
                              self._anat_file, self._mask_file)
 
+        return super(BrainExtractionRPT, self)._post_run_hook(runtime)
+
 
 # TODO: move this interface to nipype.interfaces.nilearn
-class ComputeEPIMaskInputSpec(nrc.ReportCapableInputSpec,
+class ComputeEPIMaskInputSpec(nrc.SVGReportCapableInputSpec,
                               BaseInterfaceInputSpec):
     in_file = File(exists=True, desc="3D or 4D EPI file")
     dilation = traits.Int(desc="binary dilation on the nilearn output")
 
 
-class ComputeEPIMaskOutputSpec(nrc.ReportCapableOutputSpec):
+class ComputeEPIMaskOutputSpec(reporting.ReportCapableOutputSpec):
     mask_file = File(exists=True, desc="Binary brain mask")
 
 
@@ -152,13 +157,15 @@ class ComputeEPIMask(nrc.SegmentationRC):
             'Generating report for nilearn.compute_epi_mask. file "%s", and mask file "%s"',
             self._anat_file, self._mask_file)
 
+        return super(ComputeEPIMask, self)._post_run_hook(runtime)
 
-class ACompCorInputSpecRPT(nrc.ReportCapableInputSpec,
+
+class ACompCorInputSpecRPT(nrc.SVGReportCapableInputSpec,
                            confounds.CompCorInputSpec):
     pass
 
 
-class ACompCorOutputSpecRPT(nrc.ReportCapableOutputSpec,
+class ACompCorOutputSpecRPT(reporting.ReportCapableOutputSpec,
                             confounds.CompCorOutputSpec):
     pass
 
@@ -181,13 +188,15 @@ class ACompCorRPT(nrc.SegmentationRC, confounds.ACompCor):
         NIWORKFLOWS_LOG.info('Generating report for aCompCor. file "%s", mask "%s"',
                              self.inputs.realigned_file, self._mask_file)
 
+        return super(ACompCorRPT, self)._post_run_hook(runtime)
 
-class TCompCorInputSpecRPT(nrc.ReportCapableInputSpec,
+
+class TCompCorInputSpecRPT(nrc.SVGReportCapableInputSpec,
                            confounds.TCompCorInputSpec):
     pass
 
 
-class TCompCorOutputSpecRPT(nrc.ReportCapableOutputSpec,
+class TCompCorOutputSpecRPT(reporting.ReportCapableOutputSpec,
                             confounds.TCompCorOutputSpec):
     pass
 
@@ -213,8 +222,10 @@ class TCompCorRPT(nrc.SegmentationRC, confounds.TCompCor):
                              self.inputs.realigned_file,
                              self.aggregate_outputs(runtime=runtime).high_variance_masks)
 
+        return super(TCompCorRPT, self)._post_run_hook(runtime)
 
-class SimpleShowMaskInputSpec(nrc.ReportCapableInputSpec):
+
+class SimpleShowMaskInputSpec(nrc.SVGReportCapableInputSpec):
     background_file = File(exists=True, mandatory=True, desc='file before')
     mask_file = File(exists=True, mandatory=True, desc='file before')
     generate_report = traits.Bool(True, usedefault=True)
@@ -222,7 +233,7 @@ class SimpleShowMaskInputSpec(nrc.ReportCapableInputSpec):
 
 class SimpleShowMaskRPT(nrc.SegmentationRC):
     input_spec = SimpleShowMaskInputSpec
-    output_spec = nrc.ReportCapableOutputSpec
+    output_spec = reporting.ReportCapableOutputSpec
 
     def _post_run_hook(self, runtime):
         self._anat_file = self.inputs.background_file
@@ -230,10 +241,10 @@ class SimpleShowMaskRPT(nrc.SegmentationRC):
         self._seg_files = [self.inputs.mask_file]
         self._masked = True
 
-        return runtime
+        return super(SimpleShowMaskRPT, self)._post_run_hook(runtime)
 
 
-class ROIsPlotInputSpecRPT(nrc.ReportCapableInputSpec):
+class ROIsPlotInputSpecRPT(nrc.SVGReportCapableInputSpec):
     in_file = File(exists=True, mandatory=True, desc='the volume where ROIs are defined')
     in_rois = InputMultiPath(File(exists=True), mandatory=True,
                              desc='a list of regions to be plotted')
@@ -243,12 +254,14 @@ class ROIsPlotInputSpecRPT(nrc.ReportCapableInputSpec):
                            desc='use specific colors for contours')
 
 
-class ROIsPlot(nrc.SegmentationRC):
+class ROIsPlot(reporting.ReportCapableInterface):
     input_spec = ROIsPlotInputSpecRPT
-    output_spec = nrc.ReportCapableOutputSpec
+    output_spec = reporting.ReportCapableOutputSpec
 
     def _run_interface(self, runtime):
-        """ there is not inner interface to run """
+        return runtime
+
+    def _generate_report(self):
         from niworkflows.viz.utils import plot_segs, compose_view
         seg_files = self.inputs.in_rois
         mask_file = None
@@ -270,4 +283,3 @@ class ROIsPlot(nrc.SegmentationRC):
             fg_svgs=None,
             out_file=self._out_report
         )
-        return runtime

--- a/niworkflows/interfaces/masks.py
+++ b/niworkflows/interfaces/masks.py
@@ -230,15 +230,8 @@ class SimpleShowMaskInputSpec(nrc.SVGReportCapableInputSpec):
     mask_file = File(exists=True, mandatory=True, desc='file before')
 
 
-class SimpleShowMaskRPT(nrc.SegmentationRC):
+class SimpleShowMaskRPT(nrc.SegmentationRC, nrc.ReportingInterface):
     input_spec = SimpleShowMaskInputSpec
-    output_spec = reporting.ReportCapableOutputSpec
-
-    def __init__(self, generate_report=True, **kwargs):
-        super(SimpleShowMaskRPT, self).__init__(generate_report=generate_report, **kwargs)
-
-    def _run_interface(self, runtime):
-        return runtime
 
     def _post_run_hook(self, runtime):
         self._anat_file = self.inputs.background_file
@@ -259,12 +252,8 @@ class ROIsPlotInputSpecRPT(nrc.SVGReportCapableInputSpec):
                            desc='use specific colors for contours')
 
 
-class ROIsPlot(reporting.ReportCapableInterface):
+class ROIsPlot(nrc.ReportingInterface):
     input_spec = ROIsPlotInputSpecRPT
-    output_spec = reporting.ReportCapableOutputSpec
-
-    def _run_interface(self, runtime):
-        return runtime
 
     def _generate_report(self):
         from niworkflows.viz.utils import plot_segs, compose_view

--- a/niworkflows/interfaces/masks.py
+++ b/niworkflows/interfaces/masks.py
@@ -237,6 +237,9 @@ class SimpleShowMaskRPT(nrc.SegmentationRC):
     def __init__(self, generate_report=True, **kwargs):
         super(SimpleShowMaskRPT, self).__init__(generate_report=generate_report, **kwargs)
 
+    def _run_interface(self, runtime):
+        return runtime
+
     def _post_run_hook(self, runtime):
         self._anat_file = self.inputs.background_file
         self._mask_file = self.inputs.mask_file

--- a/niworkflows/interfaces/registration.py
+++ b/niworkflows/interfaces/registration.py
@@ -17,6 +17,7 @@ from .. import NIWORKFLOWS_LOG
 from ..nipype.utils.filemanip import fname_presuffix
 from ..nipype.interfaces.base import (
     traits, isdefined, TraitedSpec, BaseInterfaceInputSpec, File, SimpleInterface)
+from ..nipype.interfaces.mixins import reporting
 from ..nipype.interfaces import freesurfer as fs
 from ..nipype.interfaces import fsl, ants, afni
 
@@ -30,12 +31,12 @@ from .fixes import (FixHeaderApplyTransforms as ApplyTransforms,
 
 
 class RobustMNINormalizationInputSpecRPT(
-        nrc.ReportCapableInputSpec, RobustMNINormalizationInputSpec):
+        nrc.SVGReportCapableInputSpec, RobustMNINormalizationInputSpec):
     pass
 
 
 class RobustMNINormalizationOutputSpecRPT(
-        nrc.ReportCapableOutputSpec, ants.registration.RegistrationOutputSpec):
+        reporting.ReportCapableOutputSpec, ants.registration.RegistrationOutputSpec):
     pass
 
 
@@ -56,13 +57,15 @@ class RobustMNINormalizationRPT(
         NIWORKFLOWS_LOG.info('Report - setting fixed (%s) and moving (%s) images',
                              self._fixed_image, self._moving_image)
 
+        return super(RobustMNINormalizationRPT, self)._post_run_hook(runtime)
 
-class ANTSRegistrationInputSpecRPT(nrc.ReportCapableInputSpec,
+
+class ANTSRegistrationInputSpecRPT(nrc.SVGReportCapableInputSpec,
                                    ants.registration.RegistrationInputSpec):
     pass
 
 
-class ANTSRegistrationOutputSpecRPT(nrc.ReportCapableOutputSpec,
+class ANTSRegistrationOutputSpecRPT(reporting.ReportCapableOutputSpec,
                                     ants.registration.RegistrationOutputSpec):
     pass
 
@@ -77,13 +80,15 @@ class ANTSRegistrationRPT(nrc.RegistrationRC, Registration):
         NIWORKFLOWS_LOG.info('Report - setting fixed (%s) and moving (%s) images',
                              self._fixed_image, self._moving_image)
 
+        return super(ANTSRegistrationRPT, self)._post_run_hook(runtime)
 
-class ANTSApplyTransformsInputSpecRPT(nrc.ReportCapableInputSpec,
+
+class ANTSApplyTransformsInputSpecRPT(nrc.SVGReportCapableInputSpec,
                                       ants.resampling.ApplyTransformsInputSpec):
     pass
 
 
-class ANTSApplyTransformsOutputSpecRPT(nrc.ReportCapableOutputSpec,
+class ANTSApplyTransformsOutputSpecRPT(reporting.ReportCapableOutputSpec,
                                        ants.resampling.ApplyTransformsOutputSpec):
     pass
 
@@ -98,14 +103,16 @@ class ANTSApplyTransformsRPT(nrc.RegistrationRC, ApplyTransforms):
         NIWORKFLOWS_LOG.info('Report - setting fixed (%s) and moving (%s) images',
                              self._fixed_image, self._moving_image)
 
+        return super(ANTSApplyTransformsRPT, self)._post_run_hook(runtime)
 
-class ApplyTOPUPInputSpecRPT(nrc.ReportCapableInputSpec,
+
+class ApplyTOPUPInputSpecRPT(nrc.SVGReportCapableInputSpec,
                              fsl.epi.ApplyTOPUPInputSpec):
     wm_seg = File(argstr='-wmseg %s',
                   desc='reference white matter segmentation mask')
 
 
-class ApplyTOPUPOutputSpecRPT(nrc.ReportCapableOutputSpec,
+class ApplyTOPUPOutputSpecRPT(reporting.ReportCapableOutputSpec,
                               fsl.epi.ApplyTOPUPOutputSpec):
     pass
 
@@ -123,14 +130,16 @@ class ApplyTOPUPRPT(nrc.RegistrationRC, fsl.ApplyTOPUP):
         NIWORKFLOWS_LOG.info('Report - setting corrected (%s) and warped (%s) images',
                              self._fixed_image, self._moving_image)
 
+        return super(ApplyTOPUPRPT, self)._post_run_hook(runtime)
 
-class FUGUEInputSpecRPT(nrc.ReportCapableInputSpec,
+
+class FUGUEInputSpecRPT(nrc.SVGReportCapableInputSpec,
                         fsl.preprocess.FUGUEInputSpec):
     wm_seg = File(argstr='-wmseg %s',
                   desc='reference white matter segmentation mask')
 
 
-class FUGUEOutputSpecRPT(nrc.ReportCapableOutputSpec,
+class FUGUEOutputSpecRPT(reporting.ReportCapableOutputSpec,
                          fsl.preprocess.FUGUEOutputSpec):
     pass
 
@@ -149,13 +158,15 @@ class FUGUERPT(nrc.RegistrationRC, fsl.FUGUE):
             'Report - setting corrected (%s) and warped (%s) images',
             self._fixed_image, self._moving_image)
 
+        return super(FUGUERPT, self)._post_run_hook(runtime)
 
-class FLIRTInputSpecRPT(nrc.ReportCapableInputSpec,
+
+class FLIRTInputSpecRPT(nrc.SVGReportCapableInputSpec,
                         fsl.preprocess.FLIRTInputSpec):
     pass
 
 
-class FLIRTOutputSpecRPT(nrc.ReportCapableOutputSpec,
+class FLIRTOutputSpecRPT(reporting.ReportCapableOutputSpec,
                          fsl.preprocess.FLIRTOutputSpec):
     pass
 
@@ -172,8 +183,10 @@ class FLIRTRPT(nrc.RegistrationRC, fsl.FLIRT):
             'Report - setting fixed (%s) and moving (%s) images',
             self._fixed_image, self._moving_image)
 
+        return super(FLIRTRPT, self)._post_run_hook(runtime)
 
-class ApplyXFMInputSpecRPT(nrc.ReportCapableInputSpec,
+
+class ApplyXFMInputSpecRPT(nrc.SVGReportCapableInputSpec,
                            fsl.preprocess.ApplyXFMInputSpec):
     pass
 
@@ -184,20 +197,20 @@ class ApplyXFMRPT(FLIRTRPT, fsl.ApplyXFM):
 
 
 if LooseVersion("0.0.0") < fs.Info.looseversion() < LooseVersion("6.0.0"):
-    class BBRegisterInputSpecRPT(nrc.ReportCapableInputSpec,
-                                 fs.preprocess.BBRegisterInputSpec):
-        out_lta_file = traits.Either(traits.Bool, File, default=True, usedefault=True,
-                                     argstr="--lta %s", min_ver='5.2.0',
-                                     desc="write the transformation matrix in LTA format")
+    _BBRegisterInputSpec = fs.preprocess.BBRegisterInputSpec
 else:
-    class BBRegisterInputSpecRPT(nrc.ReportCapableInputSpec,
-                                 fs.preprocess.BBRegisterInputSpec6):
-        out_lta_file = traits.Either(traits.Bool, File, default=True, usedefault=True,
-                                     argstr="--lta %s", min_ver='5.2.0',
-                                     desc="write the transformation matrix in LTA format")
+    _BBRegisterInputSpec = fs.preprocess.BBRegisterInputSpec6
 
 
-class BBRegisterOutputSpecRPT(nrc.ReportCapableOutputSpec,
+class BBRegisterInputSpecRPT(nrc.SVGReportCapableInputSpec,
+                             _BBRegisterInputSpec):
+    # Adds default=True, usedefault=True
+    out_lta_file = traits.Either(traits.Bool, File, default=True, usedefault=True,
+                                 argstr="--lta %s", min_ver='5.2.0',
+                                 desc="write the transformation matrix in LTA format")
+
+
+class BBRegisterOutputSpecRPT(reporting.ReportCapableOutputSpec,
                               fs.preprocess.BBRegisterOutputSpec):
     pass
 
@@ -227,13 +240,15 @@ class BBRegisterRPT(nrc.RegistrationRC, fs.BBRegister):
             'Report - setting fixed (%s) and moving (%s) images',
             self._fixed_image, self._moving_image)
 
+        return super(BBRegisterRPT, self)._post_run_hook(runtime)
 
-class MRICoregInputSpecRPT(nrc.ReportCapableInputSpec,
+
+class MRICoregInputSpecRPT(nrc.SVGReportCapableInputSpec,
                            fs.registration.MRICoregInputSpec):
     pass
 
 
-class MRICoregOutputSpecRPT(nrc.ReportCapableOutputSpec,
+class MRICoregOutputSpecRPT(reporting.ReportCapableOutputSpec,
                             fs.registration.MRICoregOutputSpec):
     pass
 
@@ -270,36 +285,30 @@ class MRICoregRPT(nrc.RegistrationRC, fs.MRICoreg):
             'Report - setting fixed (%s) and moving (%s) images',
             self._fixed_image, self._moving_image)
 
+        return super(MRICoregRPT, self)._post_run_hook(runtime)
 
-class SimpleBeforeAfterInputSpecRPT(nrc.ReportCapableInputSpec):
+
+class SimpleBeforeAfterInputSpecRPT(nrc.SVGReportCapableInputSpec):
     before = File(exists=True, mandatory=True, desc='file before')
     after = File(exists=True, mandatory=True, desc='file after')
     wm_seg = File(desc='reference white matter segmentation mask')
 
 
-class SimpleBeforeAfterOutputSpecRPT(nrc.ReportCapableOutputSpec):
-    pass
-
-
 class SimpleBeforeAfterRPT(nrc.RegistrationRC):
     input_spec = SimpleBeforeAfterInputSpecRPT
-    output_spec = SimpleBeforeAfterOutputSpecRPT
+    output_spec = reporting.ReportCapableOutputSpec
+
+    _fixed_image_label = "after"
+    _moving_image_label = "before"
 
     def _run_interface(self, runtime):
         """ there is not inner interface to run """
-        self._out_report = os.path.abspath(self.inputs.out_report)
-
-        self._fixed_image_label = "after"
-        self._moving_image_label = "before"
         self._fixed_image = self.inputs.after
         self._moving_image = self.inputs.before
         self._contour = self.inputs.wm_seg if isdefined(self.inputs.wm_seg) else None
         NIWORKFLOWS_LOG.info(
             'Report - setting before (%s) and after (%s) images',
             self._fixed_image, self._moving_image)
-
-        self._generate_report()
-        NIWORKFLOWS_LOG.info('Successfully created report (%s)', self._out_report)
 
         return runtime
 
@@ -312,21 +321,19 @@ class ResampleBeforeAfterRPT(SimpleBeforeAfterRPT):
     input_spec = ResampleBeforeAfterInputSpecRPT
 
     def _run_interface(self, runtime):
-        """ there is not inner interface to run """
-        self._out_report = os.path.abspath(self.inputs.out_report)
+        return runtime
 
-        self._fixed_image_label = "after"
-        self._moving_image_label = "before"
+    def _post_run_hook(self, runtime):
         self._fixed_image = self.inputs.after
         self._moving_image = self.inputs.before
         if self.inputs.base == 'before':
             resampled_after = nli.resample_to_img(self._fixed_image, self._moving_image)
-            fname = fname_presuffix(self._fixed_image, suffix='_resampled', newpath='.')
+            fname = fname_presuffix(self._fixed_image, suffix='_resampled', newpath=runtime.cwd)
             resampled_after.to_filename(fname)
             self._fixed_image = os.path.abspath(fname)
         else:
             resampled_before = nli.resample_to_img(self._moving_image, self._fixed_image)
-            fname = fname_presuffix(self._moving_image, suffix='_resampled', newpath='.')
+            fname = fname_presuffix(self._moving_image, suffix='_resampled', newpath=runtime.cwd)
             resampled_before.to_filename(fname)
             self._moving_image = os.path.abspath(fname)
         self._contour = self.inputs.wm_seg if isdefined(self.inputs.wm_seg) else None
@@ -334,7 +341,7 @@ class ResampleBeforeAfterRPT(SimpleBeforeAfterRPT):
             'Report - setting before (%s) and after (%s) images',
             self._fixed_image, self._moving_image)
 
-        self._generate_report()
+        runtime = super(ResampleBeforeAfterRPT, self)._post_run_hook(runtime)
         NIWORKFLOWS_LOG.info('Successfully created report (%s)', self._out_report)
         os.unlink(fname)
 

--- a/niworkflows/interfaces/registration.py
+++ b/niworkflows/interfaces/registration.py
@@ -294,14 +294,13 @@ class SimpleBeforeAfterInputSpecRPT(nrc.SVGReportCapableInputSpec):
     wm_seg = File(desc='reference white matter segmentation mask')
 
 
-class SimpleBeforeAfterRPT(nrc.RegistrationRC):
+class SimpleBeforeAfterRPT(nrc.RegistrationRC, nrc.ReportingInterface):
     input_spec = SimpleBeforeAfterInputSpecRPT
-    output_spec = reporting.ReportCapableOutputSpec
 
     _fixed_image_label = "after"
     _moving_image_label = "before"
 
-    def _run_interface(self, runtime):
+    def _post_run_hook(self, runtime):
         """ there is not inner interface to run """
         self._fixed_image = self.inputs.after
         self._moving_image = self.inputs.before
@@ -310,7 +309,7 @@ class SimpleBeforeAfterRPT(nrc.RegistrationRC):
             'Report - setting before (%s) and after (%s) images',
             self._fixed_image, self._moving_image)
 
-        return runtime
+        return super(SimpleBeforeAfterRPT, self)._post_run_hook(runtime)
 
 
 class ResampleBeforeAfterInputSpecRPT(SimpleBeforeAfterInputSpecRPT):
@@ -319,9 +318,6 @@ class ResampleBeforeAfterInputSpecRPT(SimpleBeforeAfterInputSpecRPT):
 
 class ResampleBeforeAfterRPT(SimpleBeforeAfterRPT):
     input_spec = ResampleBeforeAfterInputSpecRPT
-
-    def _run_interface(self, runtime):
-        return runtime
 
     def _post_run_hook(self, runtime):
         self._fixed_image = self.inputs.after

--- a/niworkflows/interfaces/report_base.py
+++ b/niworkflows/interfaces/report_base.py
@@ -135,3 +135,17 @@ class SurfaceSegmentationRC(reporting.ReportCapableInterface):
             [],
             out_file=self._out_report
         )
+
+
+class ReportingInterface(reporting.ReportCapableInterface):
+    """Interface that always generates a report
+
+    A subclass must define an ``input_spec`` and override ``_generate_report``.
+    """
+    output_spec = reporting.ReportCapableOutputSpec
+
+    def __init__(self, generate_report=True, **kwargs):
+        super(ReportingInterface, self).__init__(generate_report=generate_report, **kwargs)
+
+    def _run_interface(self, runtime):
+        return runtime

--- a/niworkflows/interfaces/report_base.py
+++ b/niworkflows/interfaces/report_base.py
@@ -4,25 +4,16 @@
 """ class mixin and utilities for enabling reports for nipype interfaces """
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import os
-from sys import version_info
-from abc import abstractmethod
-from io import open
-
 from nilearn.masking import apply_mask, unmask
 from nilearn.image import threshold_img, load_img
 
-from ..nipype.interfaces.base import (
-    File, traits, BaseInterface, BaseInterfaceInputSpec, TraitedSpec)
+from ..nipype.interfaces.base import File, traits
+from ..nipype.interfaces.mixins import reporting
 from .. import NIWORKFLOWS_LOG
 from ..viz.utils import cuts_from_bbox, compose_view
 
-PY3 = version_info[0] > 2
 
-
-class ReportCapableInputSpec(BaseInterfaceInputSpec):
-    generate_report = traits.Bool(
-        False, usedefault=True, desc="Set to true to enable report generation for node")
+class SVGReportCapableInputSpec(reporting.ReportCapableInputSpec):
     out_report = File(
         'report.svg', usedefault=True, desc='filename for the visual report')
     compress_report = traits.Enum('auto', True, False, usedefault=True,
@@ -32,94 +23,14 @@ class ReportCapableInputSpec(BaseInterfaceInputSpec):
                                        "False - don't attempt to compress")
 
 
-class ReportCapableOutputSpec(TraitedSpec):
-    out_report = File(desc='filename for the visual report')
-
-
-class ReportCapableInterface(BaseInterface):
-
-    """ temporary mixin to enable reports for nipype interfaces """
-
-    def __init__(self, **inputs):
-        self._out_report = None
-        super(ReportCapableInterface, self).__init__(**inputs)
-
-    def _run_interface(self, runtime):
-        """ delegates to base interface run method, then attempts to generate reports """
-        try:
-            runtime = super(
-                ReportCapableInterface, self)._run_interface(runtime)
-        except NotImplementedError:
-            pass  # the interface is derived from BaseInterface
-
-        # leave early if there's nothing to do
-        if not self.inputs.generate_report:
-            return runtime
-
-        self._out_report = os.path.abspath(self.inputs.out_report)
-        self._post_run_hook(runtime)
-
-        # check exit code and act consequently
-        NIWORKFLOWS_LOG.debug('Running report generation code')
-
-        if hasattr(runtime, 'returncode') and runtime.returncode not in [0, None]:
-            self._generate_error_report(
-                errno=runtime.get('returncode', None))
-        else:
-            self._generate_report()
-            NIWORKFLOWS_LOG.info('Successfully created report (%s)',
-                                 self._out_report)
-
-        return runtime
-
-    def _list_outputs(self):
-        try:
-            outputs = super(ReportCapableInterface, self)._list_outputs()
-        except NotImplementedError:
-            outputs = {}
-        if self._out_report is not None:
-            outputs['out_report'] = self._out_report
-        return outputs
-
-    @abstractmethod
-    def _post_run_hook(self, runtime):
-        """ A placeholder to run stuff after the normal execution of the
-        interface (i.e. assign proper inputs to reporting functions) """
-        pass
-
-    @abstractmethod
-    def _generate_report(self):
-        """
-        Saves an svg object.
-        """
-        raise NotImplementedError
-
-    def _generate_error_report(self, errno=None):
-        """ Saves an svg snippet """
-        # as of now we think this will be the same for every interface
-        NIWORKFLOWS_LOG.warn('Report was not generated')
-
-        errorstr = '<div><span class="error">Failed to generate report!</span>.\n'
-        if errno:
-            errorstr += (' <span class="error">Interface returned exit '
-                         'code %d</span>.\n') % errno
-        errorstr += '</div>\n'
-        with open(self._out_report, 'w' if PY3 else 'wb') as outfile:
-            outfile.write(errorstr)
-
-
-class RegistrationRC(ReportCapableInterface):
-
+class RegistrationRC(reporting.ReportCapableInterface):
     """ An abstract mixin to registration nipype interfaces """
-
-    def __init__(self, **inputs):
-        self._fixed_image = None
-        self._moving_image = None
-        self._fixed_image_mask = None
-        self._fixed_image_label = "fixed"
-        self._moving_image_label = "moving"
-        self._contour = None
-        super(RegistrationRC, self).__init__(**inputs)
+    _fixed_image = None
+    _moving_image = None
+    _fixed_image_mask = None
+    _fixed_image_label = "fixed"
+    _moving_image_label = "moving"
+    _contour = None
 
     def _generate_report(self):
         """ Generates the visual report """
@@ -167,7 +78,7 @@ class RegistrationRC(ReportCapableInterface):
         )
 
 
-class SegmentationRC(ReportCapableInterface):
+class SegmentationRC(reporting.ReportCapableInterface):
 
     """ An abstract mixin to segmentation nipype interfaces """
 
@@ -187,15 +98,12 @@ class SegmentationRC(ReportCapableInterface):
         )
 
 
-class SurfaceSegmentationRC(ReportCapableInterface):
+class SurfaceSegmentationRC(reporting.ReportCapableInterface):
 
     """ An abstract mixin to registration nipype interfaces """
-
-    def __init__(self, **inputs):
-        self._anat_file = None
-        self._mask_file = None
-        self._contour = None
-        super(SurfaceSegmentationRC, self).__init__(**inputs)
+    _anat_file = None
+    _mask_file = None
+    _contour = None
 
     def _generate_report(self):
         """ Generates the visual report """

--- a/niworkflows/interfaces/segmentation.py
+++ b/niworkflows/interfaces/segmentation.py
@@ -106,7 +106,7 @@ class MELODICOutputSpecRPT(reporting.ReportCapableOutputSpec,
     pass
 
 
-class MELODICRPT(nrc.ReportCapableInterface, fsl.MELODIC):
+class MELODICRPT(reporting.ReportCapableInterface, fsl.MELODIC):
     input_spec = MELODICInputSpecRPT
     output_spec = MELODICOutputSpecRPT
 
@@ -146,7 +146,7 @@ class ICA_AROMAOutputSpecRPT(reporting.ReportCapableOutputSpec,
     pass
 
 
-class ICA_AROMARPT(nrc.ReportCapableInterface, fsl.ICA_AROMA):
+class ICA_AROMARPT(reporting.ReportCapableInterface, fsl.ICA_AROMA):
     input_spec = ICA_AROMAInputSpecRPT
     output_spec = ICA_AROMAOutputSpecRPT
 

--- a/niworkflows/interfaces/segmentation.py
+++ b/niworkflows/interfaces/segmentation.py
@@ -11,16 +11,17 @@ import os
 
 from ..nipype.interfaces.base import File
 from ..nipype.interfaces import fsl, freesurfer
+from ..nipype.interfaces.mixins import reporting
 from . import report_base as nrc
 from .. import NIWORKFLOWS_LOG
 
 
-class FASTInputSpecRPT(nrc.ReportCapableInputSpec,
+class FASTInputSpecRPT(nrc.SVGReportCapableInputSpec,
                        fsl.preprocess.FASTInputSpec):
     pass
 
 
-class FASTOutputSpecRPT(nrc.ReportCapableOutputSpec,
+class FASTOutputSpecRPT(reporting.ReportCapableOutputSpec,
                         fsl.preprocess.FASTOutputSpec):
     pass
 
@@ -31,7 +32,7 @@ class FASTRPT(nrc.SegmentationRC,
     output_spec = FASTOutputSpecRPT
 
     def _run_interface(self, runtime):
-        if self.inputs.generate_report:
+        if self.generate_report:
             self.inputs.segments = True
 
         return super(FASTRPT, self)._run_interface(runtime)
@@ -54,13 +55,15 @@ class FASTRPT(nrc.SegmentationRC,
                              outputs.tissue_class_map,
                              outputs.tissue_class_files)
 
+        return super(FASTRPT, self)._post_run_hook(runtime)
 
-class ReconAllInputSpecRPT(nrc.ReportCapableInputSpec,
+
+class ReconAllInputSpecRPT(nrc.SVGReportCapableInputSpec,
                            freesurfer.preprocess.ReconAllInputSpec):
     pass
 
 
-class ReconAllOutputSpecRPT(nrc.ReportCapableOutputSpec,
+class ReconAllOutputSpecRPT(reporting.ReportCapableOutputSpec,
                             freesurfer.preprocess.ReconAllOutputSpec):
     pass
 
@@ -85,8 +88,10 @@ class ReconAllRPT(nrc.SurfaceSegmentationRC, freesurfer.preprocess.ReconAll):
         NIWORKFLOWS_LOG.info('Generating report for ReconAll (subject %s)',
                              outputs.subject_id)
 
+        return super(ReconAllRPT, self)._post_run_hook(runtime)
 
-class MELODICInputSpecRPT(nrc.ReportCapableInputSpec,
+
+class MELODICInputSpecRPT(nrc.SVGReportCapableInputSpec,
                           fsl.model.MELODICInputSpec):
     out_report = File(
         'melodic_reportlet.svg', usedefault=True, desc='Filename for the visual'
@@ -96,7 +101,7 @@ class MELODICInputSpecRPT(nrc.ReportCapableInputSpec,
                             'If not set the mask will be derived from the data.')
 
 
-class MELODICOutputSpecRPT(nrc.ReportCapableOutputSpec,
+class MELODICOutputSpecRPT(reporting.ReportCapableOutputSpec,
                            fsl.model.MELODICOutputSpec):
     pass
 
@@ -123,8 +128,10 @@ class MELODICRPT(nrc.ReportCapableInterface, fsl.MELODIC):
 
         NIWORKFLOWS_LOG.info('Generating report for MELODIC')
 
+        return super(MELODICRPT, self)._post_run_hook(runtime)
 
-class ICA_AROMAInputSpecRPT(nrc.ReportCapableInputSpec,
+
+class ICA_AROMAInputSpecRPT(nrc.SVGReportCapableInputSpec,
                             fsl.aroma.ICA_AROMAInputSpec):
     out_report = File(
         'ica_aroma_reportlet.svg', usedefault=True, desc='Filename for the visual'
@@ -134,7 +141,7 @@ class ICA_AROMAInputSpecRPT(nrc.ReportCapableInputSpec,
                             'If not set the mask will be derived from the data.')
 
 
-class ICA_AROMAOutputSpecRPT(nrc.ReportCapableOutputSpec,
+class ICA_AROMAOutputSpecRPT(reporting.ReportCapableOutputSpec,
                              fsl.aroma.ICA_AROMAOutputSpec):
     pass
 
@@ -159,3 +166,5 @@ class ICA_AROMARPT(nrc.ReportCapableInterface, fsl.ICA_AROMA):
                                                    "classified_motion_ICs.txt")
 
         NIWORKFLOWS_LOG.info('Generating report for ICA AROMA')
+
+        return super(ICA_AROMARPT, self)._post_run_hook(runtime)


### PR DESCRIPTION
* `ReportCapableInputSpec` -> `SVGReportCapableInputSpec`
* Directly use Nipype's `ReportCapableOutputSpec`, `ReportCapableInterface`
* Input trait `inputs.generate_report` is now instance attribute `generate_report`
* `_post_run_hook` now generally ends with `return super._post_run_hook`

Depends on nipy/nipype#2560