### PR TITLE
CI: Let pytest-xdist auto-detect processors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,7 +115,7 @@ jobs:
               -v ${PWD}:/scratch -w /scratch \
               --entrypoint=/usr/local/miniconda/bin/py.test \
               niworkflows:py3 /root/niworkflows \
-              -n ${CIRCLE_NPROCS:-4} -v --junit-xml=/scratch/pytest.xml
+              -n auto -v --junit-xml=/scratch/pytest.xml
 
       - store_artifacts:
           path: /tmp/tests


### PR DESCRIPTION
I'm pretty sure that `$CIRCLE_NPROCS` isn't set, and there are only actually 2 processors available.