### PR TITLE
RF: os.path.abspath(x) -> os.path.join(runtime.cwd, x)

### DIFF
--- a/niworkflows/interfaces/masks.py
+++ b/niworkflows/interfaces/masks.py
@@ -134,7 +134,7 @@ class ComputeEPIMask(nrc.SegmentationRC):
         better_mask.set_data_dtype(np.uint8)
         better_mask.to_filename("mask_file.nii.gz")
 
-        self._mask_file = os.path.abspath("mask_file.nii.gz")
+        self._mask_file = os.path.join(runtime.cwd, "mask_file.nii.gz")
 
         runtime.returncode = 0
         return super(ComputeEPIMask, self)._run_interface(runtime)

--- a/niworkflows/interfaces/registration.py
+++ b/niworkflows/interfaces/registration.py
@@ -326,12 +326,12 @@ class ResampleBeforeAfterRPT(SimpleBeforeAfterRPT):
             resampled_after = nli.resample_to_img(self._fixed_image, self._moving_image)
             fname = fname_presuffix(self._fixed_image, suffix='_resampled', newpath=runtime.cwd)
             resampled_after.to_filename(fname)
-            self._fixed_image = os.path.abspath(fname)
+            self._fixed_image = fname
         else:
             resampled_before = nli.resample_to_img(self._moving_image, self._fixed_image)
             fname = fname_presuffix(self._moving_image, suffix='_resampled', newpath=runtime.cwd)
             resampled_before.to_filename(fname)
-            self._moving_image = os.path.abspath(fname)
+            self._moving_image = fname
         self._contour = self.inputs.wm_seg if isdefined(self.inputs.wm_seg) else None
         NIWORKFLOWS_LOG.info(
             'Report - setting before (%s) and after (%s) images',

--- a/niworkflows/interfaces/registration.py
+++ b/niworkflows/interfaces/registration.py
@@ -384,11 +384,11 @@ class EstimateReferenceImage(SimpleInterface):
 
         n_volumes_to_discard = _get_vols_to_discard(in_nii)
 
-        out_ref_fname = os.path.abspath("ref_image.nii.gz")
+        out_ref_fname = os.path.join(runtime.cwd, "ref_image.nii.gz")
 
         if n_volumes_to_discard == 0:
             if in_nii.shape[-1] > 40:
-                slice_fname = os.path.abspath("slice.nii.gz")
+                slice_fname = os.path.join(runtime.cwd, "slice.nii.gz")
                 nb.Nifti1Image(data_slice[:, :, :, 20:40], in_nii.affine,
                                in_nii.header).to_filename(slice_fname)
             else:

--- a/niworkflows/interfaces/utils.py
+++ b/niworkflows/interfaces/utils.py
@@ -108,7 +108,7 @@ class NormalizeMotionParams(SimpleInterface):
             func1d=normalize_mc_params,
             axis=1, arr=mpars,
             source=self.inputs.format)
-        self._results['out_file'] = os.path.abspath("motion_params.txt")
+        self._results['out_file'] = os.path.join(runtime.cwd, "motion_params.txt")
         np.savetxt(self._results['out_file'], mpars)
         return runtime
 


### PR DESCRIPTION
When `runtime` is available, and we're creating a file in the working directory, the best practice is to use `os.path.join(runtime.cwd, fname)` over `os.path.abspath(fname)`. This was established in nipy/nipype#2380, as some interfaces can fail on OSX due to whatever is going on with `/var` and `/private/var`.

Ran into this with `EstimateReferenceImage` while working on poldracklab/fmriprep#1074.

Not urgent, as I need ANTs anyway, and so have switched to working in Docker. There may be some other cases that can be moved; these were just the obvious ones.

Also removed a couple redundant calls to `os.path.abspath(fname)` when `fname` was defined with `runtime.cwd` already.