### PR TITLE
[ENH/MAINT] Refactor downloads, update NKI

### DIFF
--- a/niworkflows/data/__init__.py
+++ b/niworkflows/data/__init__.py
@@ -21,6 +21,7 @@ from .getters import (
     get_hcp32k_files,
     get_conte69_mesh,
     get_dataset,
+    get_template,
     get_bids_examples,
     TEMPLATE_MAP,
 )

--- a/niworkflows/data/getters.py
+++ b/niworkflows/data/getters.py
@@ -27,6 +27,7 @@ OSF_RESOURCES = {
     'mni152_nlin_sym_las': ('57fa7fc89ad5a101e635eeef', '9c4c0cad2a2e99d6799f01abf4107f5a'),
     'mni152_nlin_sym_ras': ('57fa7fd09ad5a101df35eed0', '65d64ad5a980da86e7d07d95b3ed2ccb'),
     'MNI152NLin2009cAsym': ('5b0dbce20f461a000db8fa3d', '5d386d7db9c1dec30230623db25e05e1'),
+    'NKI': ('5bc3fad82aa873001bc5a553', '092e56fb3700f9f57b8917a0db887db6'),
     'OASIS30ANTs': ('5b0dbce34c28ef0012c7f788', 'f625a0390eb32a7852c7b0d71ac428cd'),
     'OASISTRT20': ('5b16f17aeca4a80012bd7542', '1b5389bc3a895b2bd5c0d47401107176'),
 }

--- a/niworkflows/data/getters.py
+++ b/niworkflows/data/getters.py
@@ -42,10 +42,9 @@ BIDS_EXAMPLES = {
 
 # Map names of templates to OSF_RESOURCES keys
 TEMPLATE_MAP = {
-    'fMRIPrep': 'fMRIPrep',
     'MNI152NLin2009cAsym': 'MNI152NLin2009cAsym',
     'OASIS': 'OASIS30ANTs',
-    'NKI': 'ants_nki_template_ras',
+    'NKI': 'NKI',
 }
 
 
@@ -70,6 +69,10 @@ def get_template(template_name, data_dir=None, url=None, resume=True, verbose=1)
     """Download and load a template"""
     if template_name.startswith('tpl-'):
         template_name =  template_name[4:]
+
+    # An aliasing mechanism. Please avoid
+    if template_name in TEMPLATE_MAP:
+        template_name = TEMPLATE_MAP[template_name]
     return get_dataset(template_name, dataset_prefix='tpl-', data_dir=data_dir,
                        url=url, resume=resume, verbose=verbose)
 

--- a/niworkflows/data/getters.py
+++ b/niworkflows/data/getters.py
@@ -86,7 +86,8 @@ def get_brainweb_1mm_normal(data_dir=None, url=None, resume=True, verbose=1):
     :param str url: download URL of the dataset. Overwrite the default URL.
 
     """
-    return get_dataset('brainweb', data_dir, url, resume, verbose)
+    return get_dataset('brainweb', data_dir=data_dir, url=url,
+                       resume=resume, verbose=verbose)
 
 
 def get_ds003_downsampled(data_dir=None, url=None, resume=True, verbose=1):
@@ -98,7 +99,8 @@ def get_ds003_downsampled(data_dir=None, url=None, resume=True, verbose=1):
     :param str url: download URL of the dataset. Overwrite the default URL.
 
     """
-    return get_dataset('ds003_downsampled', data_dir, url, resume, verbose)
+    return get_dataset('ds003_downsampled', data_dir=data_dir, url=url,
+                       resume=resume, verbose=verbose)
 
 
 def get_mni_template(data_dir=None, url=None, resume=True, verbose=1):
@@ -110,7 +112,8 @@ def get_mni_template(data_dir=None, url=None, resume=True, verbose=1):
     :param str url: download URL of the dataset. Overwrite the default URL.
 
     """
-    return get_dataset('mni_template', data_dir, url, resume, verbose)
+    return get_dataset('mni_template', data_dir=data_dir, url=url,
+                       resume=resume, verbose=verbose)
 
 
 def get_mni_template_ras(data_dir=None, url=None, resume=True, verbose=1):
@@ -119,7 +122,8 @@ def get_mni_template_ras(data_dir=None, url=None, resume=True, verbose=1):
         in a non-standard location.
     :param str url: download URL of the dataset. Overwrite the default URL.
     """
-    return get_dataset('mni_template_RAS', data_dir, url, resume, verbose)
+    return get_dataset('mni_template_RAS', data_dir=data_dir, url=url,
+                       resume=resume, verbose=verbose)
 
 
 def get_mni_epi(data_dir=None, url=None, resume=True, verbose=1):
@@ -128,7 +132,8 @@ def get_mni_epi(data_dir=None, url=None, resume=True, verbose=1):
         in a non-standard location.
     :param str url: download URL of the dataset. Overwrite the default URL.
     """
-    return get_dataset('mni_epi', data_dir, url, resume, verbose)
+    return get_dataset('mni_epi', data_dir=data_dir, url=url,
+                       resume=resume, verbose=verbose)
 
 
 def get_ants_oasis_template(data_dir=None, url=None, resume=True, verbose=1):
@@ -137,7 +142,8 @@ def get_ants_oasis_template(data_dir=None, url=None, resume=True, verbose=1):
         in a non-standard location.
     :param str url: download URL of the dataset. Overwrite the default URL.
     """
-    return get_dataset('ants_oasis_template', data_dir, url, resume, verbose)
+    return get_dataset('ants_oasis_template', data_dir=data_dir, url=url,
+                       resume=resume, verbose=verbose)
 
 
 def get_ants_oasis_template_ras(data_dir=None, url=None, resume=True, verbose=1):
@@ -146,7 +152,8 @@ def get_ants_oasis_template_ras(data_dir=None, url=None, resume=True, verbose=1)
         in a non-standard location.
     :param str url: download URL of the dataset. Overwrite the default URL.
     """
-    return get_dataset('ants_oasis_template_ras', data_dir, url, resume, verbose)
+    return get_dataset('ants_oasis_template_ras', data_dir=data_dir, url=url,
+                       resume=resume, verbose=verbose)
 
 
 def get_ants_nki_template_ras(data_dir=None, url=None, resume=True, verbose=1):
@@ -155,7 +162,8 @@ def get_ants_nki_template_ras(data_dir=None, url=None, resume=True, verbose=1):
         in a non-standard location.
     :param str url: download URL of the dataset. Overwrite the default URL.
     """
-    return get_dataset('ants_nki_template_ras', data_dir, url, resume, verbose)
+    return get_dataset('ants_nki_template_ras', data_dir=data_dir, url=url,
+                       resume=resume, verbose=verbose)
 
 
 def get_mni152_nlin_sym_las(data_dir=None, url=None, resume=True, verbose=1):
@@ -164,7 +172,8 @@ def get_mni152_nlin_sym_las(data_dir=None, url=None, resume=True, verbose=1):
         in a non-standard location.
     :param str url: download URL of the dataset. Overwrite the default URL.
     """
-    return get_dataset('mni152_nlin_sym_las', data_dir, url, resume, verbose)
+    return get_dataset('mni152_nlin_sym_las', data_dir=data_dir, url=url,
+                       resume=resume, verbose=verbose)
 
 
 def get_mni152_nlin_sym_ras(data_dir=None, url=None, resume=True, verbose=1):
@@ -173,11 +182,13 @@ def get_mni152_nlin_sym_ras(data_dir=None, url=None, resume=True, verbose=1):
         in a non-standard location.
     :param str url: download URL of the dataset. Overwrite the default URL.
     """
-    return get_dataset('mni152_nlin_sym_ras', data_dir, url, resume, verbose)
+    return get_dataset('mni152_nlin_sym_ras', data_dir=data_dir, url=url,
+                       resume=resume, verbose=verbose)
 
 
 def get_mni_icbm152_nlin_asym_09c(data_dir=None, url=None, resume=True, verbose=1):
-    return get_dataset('mni_icbm152_nlin_asym_09c', data_dir, url, resume, verbose)
+    return get_dataset('mni_icbm152_nlin_asym_09c', data_dir=data_dir, url=url,
+                       resume=resume, verbose=verbose)
 
 
 def get_mni_icbm152_linear(data_dir=None, url=None, resume=True, verbose=1):
@@ -186,7 +197,8 @@ def get_mni_icbm152_linear(data_dir=None, url=None, resume=True, verbose=1):
         in a non-standard location.
     :param str url: download URL of the dataset. Overwrite the default URL.
     """
-    return get_dataset('mni_icbm152_linear', data_dir, url, resume, verbose)
+    return get_dataset('mni_icbm152_linear', data_dir=data_dir, url=url,
+                       resume=resume, verbose=verbose)
 
 
 def get_bids_examples(data_dir=None, url=None, resume=True, verbose=1,
@@ -209,7 +221,8 @@ def get_oasis_dkt31_mni152(data_dir=None, url=None, resume=True, verbose=1):
         in a non-standard location.
     :param str url: download URL of the dataset. Overwrite the default URL.
     """
-    return get_template('OASISTRT20', data_dir, url, resume, verbose)
+    return get_template('OASISTRT20', data_dir=data_dir, url=url,
+                        resume=resume, verbose=verbose)
 
 
 def get_hcp32k_files(data_dir=None, url=None, resume=True, verbose=1):
@@ -219,7 +232,8 @@ def get_hcp32k_files(data_dir=None, url=None, resume=True, verbose=1):
         in a non-standard location.
     :param str url: download URL of the dataset. Overwrite the default URL.
     """
-    return get_template('hcpLR32k', data_dir, url, resume, verbose)
+    return get_template('hcpLR32k', data_dir=data_dir, url=url,
+                        resume=resume, verbose=verbose)
 
 
 def get_conte69_mesh(data_dir=None, url=None, resume=True, verbose=1):
@@ -228,4 +242,5 @@ def get_conte69_mesh(data_dir=None, url=None, resume=True, verbose=1):
         in a non-standard location.
     :param str url: download URL of the dataset. Overwrite the default URL.
     """
-    return get_template('conte69', data_dir, url, resume, verbose)
+    return get_template('conte69', data_dir=data_dir, url=url,
+                        resume=resume, verbose=verbose)

--- a/niworkflows/data/getters.py
+++ b/niworkflows/data/getters.py
@@ -7,8 +7,7 @@ Data grabbers
 """
 from __future__ import print_function, division, absolute_import, unicode_literals
 
-from pathlib import Path
-from ..data.utils import _get_dataset_dir, _fetch_file
+from ..data.utils import fetch_file
 
 
 OSF_PROJECT_URL = ('https://files.osf.io/v1/resources/fvuh8/providers/osfstorage/')
@@ -43,6 +42,7 @@ BIDS_EXAMPLES = {
 
 # Map names of templates to OSF_RESOURCES keys
 TEMPLATE_MAP = {
+    'fMRIPrep': 'fMRIPrep',
     'MNI152NLin2009cAsym': 'MNI152NLin2009cAsym',
     'OASIS': 'OASIS30ANTs',
     'NKI': 'ants_nki_template_ras',
@@ -58,22 +58,12 @@ def get_dataset(dataset_name, data_dir=None, url=None, resume=True, verbose=1):
     :param str url: download URL of the dataset. Overwrite the default URL.
 
     """
-    data_dir = _get_dataset_dir(dataset_name, data_dir=data_dir, verbose=verbose)
-
-    if dataset_name in TEMPLATE_MAP:
-        dataset_name = TEMPLATE_MAP.get(dataset_name, dataset_name)
-        data_dir = str(Path(data_dir).parent / (
-            'tpl-%s' % dataset_name))
-
     file_id, md5 = OSF_RESOURCES[dataset_name]
     if url is None:
         url = '{}/{}'.format(OSF_PROJECT_URL, file_id)
 
-    if _fetch_file(url, data_dir, filetype='tar', resume=resume, verbose=verbose,
-                   md5sum=md5):
-        return data_dir
-    else:
-        return None
+    return fetch_file(dataset_name, url, data_dir, filetype='tar',
+                      resume=resume, verbose=verbose, md5sum=md5)
 
 
 def get_brainweb_1mm_normal(data_dir=None, url=None, resume=True, verbose=1):

--- a/niworkflows/data/getters.py
+++ b/niworkflows/data/getters.py
@@ -69,11 +69,10 @@ def get_dataset(dataset_name, dataset_prefix=None, data_dir=None,
 def get_template(template_name, data_dir=None, url=None, resume=True, verbose=1):
     """Download and load a template"""
     if template_name.startswith('tpl-'):
-        template_name =  template_name[4:]
+        template_name = template_name[4:]
 
     # An aliasing mechanism. Please avoid
-    if template_name in TEMPLATE_MAP:
-        template_name = TEMPLATE_MAP[template_name]
+    template_name = TEMPLATE_MAP.get(template_name, template_name)
     return get_dataset(template_name, dataset_prefix='tpl-', data_dir=data_dir,
                        url=url, resume=resume, verbose=verbose)
 
@@ -190,24 +189,17 @@ def get_mni_icbm152_linear(data_dir=None, url=None, resume=True, verbose=1):
     return get_dataset('mni_icbm152_linear', data_dir, url, resume, verbose)
 
 
-def get_bids_examples(data_dir=None, url=None, resume=True, verbose=1, variant=None):
+def get_bids_examples(data_dir=None, url=None, resume=True, verbose=1,
+                      variant='BIDS-examples-1-1.0.0-rc3u5'):
     """
     Download BIDS-examples-1
     """
-
-    if variant is None or variant not in BIDS_EXAMPLES:
-        variant = 'BIDS-examples-1-1.0.0-rc3u5'
-
+    variant = 'BIDS-examples-1-1.0.0-rc3u5' if variant not in BIDS_EXAMPLES else variant
     if url is None:
         url = BIDS_EXAMPLES[variant][0]
     md5 = BIDS_EXAMPLES[variant][1]
-    data_dir = _get_dataset_dir(variant, data_dir=data_dir, verbose=verbose)
-
-    if _fetch_file(url, data_dir, filetype=None, resume=resume, verbose=verbose,
-                   md5sum=md5):
-        return data_dir
-    else:
-        return None
+    return fetch_file(variant, url, data_dir, filetype='tar',
+                      resume=resume, verbose=verbose, md5sum=md5)
 
 
 def get_oasis_dkt31_mni152(data_dir=None, url=None, resume=True, verbose=1):
@@ -217,7 +209,7 @@ def get_oasis_dkt31_mni152(data_dir=None, url=None, resume=True, verbose=1):
         in a non-standard location.
     :param str url: download URL of the dataset. Overwrite the default URL.
     """
-    return get_dataset('tpl-OASISTRT20', data_dir, url, resume, verbose)
+    return get_template('OASISTRT20', data_dir, url, resume, verbose)
 
 
 def get_hcp32k_files(data_dir=None, url=None, resume=True, verbose=1):
@@ -227,7 +219,7 @@ def get_hcp32k_files(data_dir=None, url=None, resume=True, verbose=1):
         in a non-standard location.
     :param str url: download URL of the dataset. Overwrite the default URL.
     """
-    return get_dataset('tpl-hcpLR32k', data_dir, url, resume, verbose)
+    return get_template('hcpLR32k', data_dir, url, resume, verbose)
 
 
 def get_conte69_mesh(data_dir=None, url=None, resume=True, verbose=1):
@@ -236,4 +228,4 @@ def get_conte69_mesh(data_dir=None, url=None, resume=True, verbose=1):
         in a non-standard location.
     :param str url: download URL of the dataset. Overwrite the default URL.
     """
-    return get_dataset('tpl-conte69', data_dir, url, resume, verbose)
+    return get_template('conte69', data_dir, url, resume, verbose)

--- a/niworkflows/data/getters.py
+++ b/niworkflows/data/getters.py
@@ -210,8 +210,8 @@ def get_bids_examples(data_dir=None, url=None, resume=True, verbose=1,
     if url is None:
         url = BIDS_EXAMPLES[variant][0]
     md5 = BIDS_EXAMPLES[variant][1]
-    return fetch_file(variant, url, data_dir, filetype='tar',
-                      resume=resume, verbose=verbose, md5sum=md5)
+    return fetch_file(variant, url, data_dir, resume=resume, verbose=verbose,
+                      md5sum=md5)
 
 
 def get_oasis_dkt31_mni152(data_dir=None, url=None, resume=True, verbose=1):

--- a/niworkflows/data/getters.py
+++ b/niworkflows/data/getters.py
@@ -12,23 +12,23 @@ from ..data.utils import fetch_file
 
 OSF_PROJECT_URL = ('https://files.osf.io/v1/resources/fvuh8/providers/osfstorage/')
 OSF_RESOURCES = {
-    'MNI152NLin2009cAsym': ('5b0dbce20f461a000db8fa3d', '5d386d7db9c1dec30230623db25e05e1'),
-    'OASIS30ANTs': ('5b0dbce34c28ef0012c7f788', 'f625a0390eb32a7852c7b0d71ac428cd'),
-    'brainweb': ('57f32b96b83f6901f194c3ca', '384263fbeadc8e2cca92ced98f224c4b'),
-    'ds003_downsampled': ('57f328f6b83f6901ef94cf70', '5a558961c1eb5e5f162696d8afa956e8'),
-    'mni_template': ('57f32ab29ad5a101fb77fd89', 'debfa882b8c301cd6d75dd769e73f727'),
-    'mni_template_RAS': ('57f32a799ad5a101f977eb77', 'a4669f0e7acceae148bb39450b2b21b4'),
+    'ants_nki_template_ras': ('59cd90f46c613b02b3d79782', 'e5debaee65b8f2c8971577db1327e314'),
     'ants_oasis_template': ('57f32ae89ad5a101f977eb79', '34d39070b541c416333cc8b6c2fe993c'),
     'ants_oasis_template_ras': ('584123a29ad5a1020913609d', 'afa21f99c66ae1672320d8aa0408229a'),
-    'ants_nki_template_ras': ('59cd90f46c613b02b3d79782', 'e5debaee65b8f2c8971577db1327e314'),
+    'brainweb': ('57f32b96b83f6901f194c3ca', '384263fbeadc8e2cca92ced98f224c4b'),
+    'conte69': ('5b198ec5ec24e20011b48548', 'bd944e3f9f343e0e51e562b440960529'),
+    'ds003_downsampled': ('57f328f6b83f6901ef94cf70', '5a558961c1eb5e5f162696d8afa956e8'),
+    'hcpLR32k': ('5b198ec6b796ba000f3e4858', '0ba9adcaa42fa88616a4cea5a1ce0c5a'),
     'mni_epi': ('57fa09cdb83f6901d93623a0', '9df727e1f742ec55213480434b4c4811'),
-    'mni152_nlin_sym_las': ('57fa7fc89ad5a101e635eeef', '9c4c0cad2a2e99d6799f01abf4107f5a'),
-    'mni152_nlin_sym_ras': ('57fa7fd09ad5a101df35eed0', '65d64ad5a980da86e7d07d95b3ed2ccb'),
     'mni_icbm152_linear': ('580705eb594d9001ed622649', '72be639e92532def7caad75cb4058e83'),
     'mni_icbm152_nlin_asym_09c': ('580705089ad5a101f17944a9', '002f9bf24dc5c32de50c03f01fa539ec'),
-    'tpl-OASISTRT20': ('5b16f17aeca4a80012bd7542', '1b5389bc3a895b2bd5c0d47401107176'),
-    'tpl-hcpLR32k': ('5b198ec6b796ba000f3e4858', '0ba9adcaa42fa88616a4cea5a1ce0c5a'),
-    'tpl-conte69': ('5b198ec5ec24e20011b48548', 'bd944e3f9f343e0e51e562b440960529'),
+    'mni_template': ('57f32ab29ad5a101fb77fd89', 'debfa882b8c301cd6d75dd769e73f727'),
+    'mni_template_RAS': ('57f32a799ad5a101f977eb77', 'a4669f0e7acceae148bb39450b2b21b4'),
+    'mni152_nlin_sym_las': ('57fa7fc89ad5a101e635eeef', '9c4c0cad2a2e99d6799f01abf4107f5a'),
+    'mni152_nlin_sym_ras': ('57fa7fd09ad5a101df35eed0', '65d64ad5a980da86e7d07d95b3ed2ccb'),
+    'MNI152NLin2009cAsym': ('5b0dbce20f461a000db8fa3d', '5d386d7db9c1dec30230623db25e05e1'),
+    'OASIS30ANTs': ('5b0dbce34c28ef0012c7f788', 'f625a0390eb32a7852c7b0d71ac428cd'),
+    'OASISTRT20': ('5b16f17aeca4a80012bd7542', '1b5389bc3a895b2bd5c0d47401107176'),
 }
 
 BIDS_EXAMPLES = {
@@ -49,7 +49,8 @@ TEMPLATE_MAP = {
 }
 
 
-def get_dataset(dataset_name, data_dir=None, url=None, resume=True, verbose=1):
+def get_dataset(dataset_name, dataset_prefix=None, data_dir=None,
+                url=None, resume=True, verbose=1):
     """Download and load the BIDS-fied brainweb 1mm normal
 
 
@@ -61,9 +62,16 @@ def get_dataset(dataset_name, data_dir=None, url=None, resume=True, verbose=1):
     file_id, md5 = OSF_RESOURCES[dataset_name]
     if url is None:
         url = '{}/{}'.format(OSF_PROJECT_URL, file_id)
+    return fetch_file(dataset_name, url, data_dir, dataset_prefix=dataset_prefix,
+                      filetype='tar', resume=resume, verbose=verbose, md5sum=md5)
 
-    return fetch_file(dataset_name, url, data_dir, filetype='tar',
-                      resume=resume, verbose=verbose, md5sum=md5)
+
+def get_template(template_name, data_dir=None, url=None, resume=True, verbose=1):
+    """Download and load a template"""
+    if template_name.startswith('tpl-'):
+        template_name =  template_name[4:]
+    return get_dataset(template_name, dataset_prefix='tpl-', data_dir=data_dir,
+                       url=url, resume=resume, verbose=verbose)
 
 
 def get_brainweb_1mm_normal(data_dir=None, url=None, resume=True, verbose=1):

--- a/niworkflows/data/utils.py
+++ b/niworkflows/data/utils.py
@@ -135,7 +135,8 @@ def fetch_file(dataset_name, url, dataset_dir, dataset_prefix=None,
                 NIWORKFLOWS_LOG.warn(
                     'Resuming failed, try to download the whole file.')
             return fetch_file(
-                url, dataset_dir, resume=False, overwrite=overwrite,
+                dataset_name, url, dataset_dir,
+                resume=False, overwrite=overwrite,
                 md5sum=md5sum, username=username, password=password,
                 verbose=verbose)
         local_file = open(temp_part_name, "ab")
@@ -150,7 +151,7 @@ def fetch_file(dataset_name, url, dataset_dir, dataset_prefix=None,
                                          retry + 1)
                 time.sleep(5)
                 return fetch_file(
-                    url, dataset_dir, resume=False, overwrite=overwrite,
+                    dataset_name, url, dataset_dir, resume=False, overwrite=overwrite,
                     md5sum=md5sum, username=username, password=password,
                     verbose=verbose, retry=retry + 1)
             else:

--- a/niworkflows/data/utils.py
+++ b/niworkflows/data/utils.py
@@ -9,6 +9,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import os
 import os.path as op
+from pathlib import Path
 import sys
 import shutil
 import time
@@ -30,12 +31,13 @@ from .. import NIWORKFLOWS_LOG
 
 PY3 = sys.version_info[0] > 2
 MAX_RETRIES = 20
-NIWORKFLOWS_CACHE_DIR = op.expanduser('~/.cache/stanford-crn')
+NIWORKFLOWS_CACHE_DIR = (Path.home() / '.cache' / 'stanford-crn').resolve()
 
 
-def _fetch_file(url, dataset_dir, filetype=None, resume=True, overwrite=False,
-                md5sum=None, username=None, password=None, retry=0,
-                verbose=1, temp_downloads=None):
+def fetch_file(dataset_name, url, dataset_dir, dataset_prefix=None,
+               filetype=None, resume=True, overwrite=False,
+               md5sum=None, username=None, password=None, retry=0,
+               verbose=1, temp_downloads=None):
     """Load requested file, downloading it if needed or requested.
 
     :param str url: contains the url of the file to be downloaded.
@@ -58,13 +60,16 @@ def _fetch_file(url, dataset_dir, filetype=None, resume=True, overwrite=False,
 
 
     """
+    final_path, cached = _get_dataset(dataset_name, dataset_prefix=dataset_prefix,
+                                      data_dir=data_dir, default_paths=default_paths,
+                                      verbose=verbose)
     if not overwrite and os.listdir(dataset_dir):
         return True
 
     data_dir, _ = op.split(dataset_dir)
 
     if temp_downloads is None:
-        temp_downloads = op.join(NIWORKFLOWS_CACHE_DIR, 'downloads')
+        temp_downloads = str(NIWORKFLOWS_CACHE_DIR / 'downloads')
 
     # Determine data path
     if not op.exists(temp_downloads):
@@ -197,17 +202,45 @@ def _fetch_file(url, dataset_dir, filetype=None, resume=True, overwrite=False,
     return True
 
 
-def _get_dataset_dir(dataset_name, data_dir=None, default_paths=None,
-                     verbose=1):
+def _get_data_path(data_dir=None):
+    """ Get data storage directory
+
+    data_dir: str
+      Path of the data directory. Used to force data storage in
+      a specified location.
+
+    :returns:
+        a list of paths where the dataset could be stored,
+        ordered by priority
+
+    """
+    data_dir = data_dir or ''
+
+    default_dirs = [Path(d).expanduser().resolve()
+                    for d in os.getenv('CRN_SHARED_DATA', '').split(os.pathsep)
+                    if d.strip()]
+    default_dirs += [Path(d).expanduser().resolve()
+                     for d in os.getenv('CRN_DATA', '').split(os.pathsep)
+                     if d.strip()]
+    default_dirs += [NIWORKFLOWS_CACHE_DIR]
+
+    return [Path(d).expanduser().resolve()
+            for d in data_dir.split(os.pathsep) if d.strip()] or default_dirs
+
+
+def _get_dataset(dataset_name, dataset_prefix=None,
+                 data_dir=None, default_paths=None,
+                 verbose=1):
     """ Create if necessary and returns data directory of given dataset.
 
-    :param str dataset_name: The unique name of the dataset.
-    :param str data_dir: Path of the data directory. Used to force data storage in
+    data_dir: str
+      Path of the data directory. Used to force data storage in
       a specified location.
-    :param list(str) default_paths: Default system paths in which the dataset
-      may already have been installed by a third party software. They will be
-      checked first.
-    :param int verbose: verbosity level (0 means no message).
+    default_paths: list(str)
+      Default system paths in which the dataset may already have been installed
+      by a third party software. They will be checked first.
+    verbose: int
+      verbosity level (0 means no message).
 
     :returns: the path of the given dataset directory.
     :rtype: str
@@ -225,65 +258,26 @@ def _get_dataset_dir(dataset_name, data_dir=None, default_paths=None,
 
 
     """
-    # We build an array of successive paths by priority
-    # The boolean indicates if it is a pre_dir: in that case, we won't add the
-    # dataset name to the path.
-    paths = []
 
-    # Check data_dir which force storage in a specific location
-    if data_dir is not None:
-        paths.extend([(d, False) for d in data_dir.split(os.pathsep)])
+    dataset_folder = None if not dataset_prefix else '%s%s' % (dataset_prefix, dataset_name)
+    paths = [p / dataset_folder for p in _get_data_path(data_dir)]
+    all_paths = [Path(p) / dataset_folder
+                 for p in default_paths.split(os.pathsep)] + paths
 
-    # Search possible system paths
-    if default_paths is not None:
-        for default_path in default_paths:
-            paths.extend([(d, True) for d in default_path.split(os.pathsep)])
-
-    # If data_dir has not been specified, then we crawl default locations
-    if data_dir is None:
-        global_data = os.getenv('CRN_SHARED_DATA')
-        if global_data is not None:
-            paths.extend([(d, False) for d in global_data.split(os.pathsep)])
-
-        local_data = os.getenv('CRN_DATA')
-        if local_data is not None:
-            paths.extend([(d, False) for d in local_data.split(os.pathsep)])
-
-        paths.append((NIWORKFLOWS_CACHE_DIR, False))
-
-    if verbose > 2:
-        NIWORKFLOWS_LOG.info('Dataset search paths: %s', str(paths))
-
-    # Check if the dataset exists somewhere
-    for path, is_pre_dir in paths:
-        if not is_pre_dir:
-            path = op.join(path, dataset_name)
-        if op.islink(path):
-            # Resolve path
-            path = readlinkabs(path)
-        if op.exists(path) and op.isdir(path):
+    # Check if the dataset folder exists somewhere and is not empty
+    for path in all_paths:
+        if path.is_dir() and list(path.iterdir()):
             if verbose > 1:
-                NIWORKFLOWS_LOG.info('Dataset already cached in %s', path)
-            return path
+                NIWORKFLOWS_LOG.info(
+                    'Dataset "%s" already cached in %s', dataset_name, path)
+            return path, True
 
-    # If not, create a folder in the first writeable directory
-    errors = []
-    for (path, is_pre_dir) in paths:
-        if not is_pre_dir:
-            path = op.join(path, dataset_name)
-        if not op.exists(path):
-            try:
-                os.makedirs(path)
-                if verbose > 0:
-                    NIWORKFLOWS_LOG.info('Dataset created in %s', path)
-                return path
-            except Exception as exc:
-                short_error_message = getattr(exc, 'strerror', str(exc))
-                errors.append('\n -{0} ({1})'.format(
-                    path, short_error_message))
-
-    raise OSError('niworkflows tried to store the dataset in the following '
-                  'directories, but:' + ''.join(errors))
+    for path in paths:
+        if verbose > 0:
+            NIWORKFLOWS_LOG.info(
+                'Dataset "%s" not cached, downloading to %s', dataset_name, path)
+        path.mkdir(parents=True, exist_ok=True)
+        return path, False
 
 
 def readlinkabs(link):

--- a/niworkflows/tests/test_data.py
+++ b/niworkflows/tests/test_data.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+# emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
+# vi: set ft=python sts=4 ts=4 sw=4 et:
+""" Test data """
+
+import os
+from pathlib import Path
+from niworkflows.data import utils
+
+
+def test_get_data_path(monkeypatch):
+    """ utils._get_data_path """
+    # remove env variables
+    monkeypatch.delitem(os.environ, 'CRN_SHARED_DATA', raising=False)
+    monkeypatch.delitem(os.environ, 'CRN_DATA', raising=False)
+
+    # pass explicit folders
+    assert utils._get_data_path('/some/path') == [Path('/some/path')]
+    assert utils._get_data_path('/some/path:/some/other') == \
+        [Path('/some/path'), Path('/some/other')]
+
+    # niworkflows default location
+    assert utils._get_data_path() == [utils.NIWORKFLOWS_CACHE_DIR]
+
+
+    monkeypatch.setenv('CRN_DATA', '~/.crn-data')
+    # pass explicit folders
+    assert utils._get_data_path('/some/path') == [Path('/some/path')]
+    assert utils._get_data_path('/some/path:/some/other') == \
+        [Path('/some/path'), Path('/some/other')]
+    # niworkflows default location
+    assert utils._get_data_path() == [Path('~/.crn-data').expanduser().resolve(),
+                                      utils.NIWORKFLOWS_CACHE_DIR]
+
+    monkeypatch.setenv('CRN_DATA', '~/.crn-data:/usr/local/share/crn-data')
+    # niworkflows default location
+    assert utils._get_data_path() == [Path('~/.crn-data').expanduser().resolve(),
+                                      Path('/usr/local/share/crn-data'),
+                                      utils.NIWORKFLOWS_CACHE_DIR]
+
+    monkeypatch.setenv('CRN_DATA', '~/.crn-data:/usr/local/share/crn-data:')
+    # niworkflows default location
+    assert utils._get_data_path() == [Path('~/.crn-data').expanduser().resolve(),
+                                      Path('/usr/local/share/crn-data'),
+                                      utils.NIWORKFLOWS_CACHE_DIR]
+
+    monkeypatch.setenv('CRN_DATA', '~/.crn-data')
+    monkeypatch.setenv('CRN_SHARED_DATA', '/usr/local/share/crn-data:')
+    # pass explicit folders
+    assert utils._get_data_path('/some/path') == [Path('/some/path')]
+    assert utils._get_data_path('/some/path:/some/other') == \
+        [Path('/some/path'), Path('/some/other')]
+    # niworkflows default location
+    assert utils._get_data_path() == [Path('/usr/local/share/crn-data'),
+                                      Path('~/.crn-data').expanduser().resolve(),
+                                      utils.NIWORKFLOWS_CACHE_DIR]

--- a/niworkflows/tests/test_data.py
+++ b/niworkflows/tests/test_data.py
@@ -22,7 +22,6 @@ def test_get_data_path(monkeypatch):
     # niworkflows default location
     assert utils._get_data_path() == [utils.NIWORKFLOWS_CACHE_DIR]
 
-
     monkeypatch.setenv('CRN_DATA', '~/.crn-data')
     # pass explicit folders
     assert utils._get_data_path('/some/path') == [Path('/some/path')]


### PR DESCRIPTION
- Added a new convenience method `get_template` that handles the `tpl-` prefix in a more reliable way.
- Organized list of datasets alphabetically
- Added a standardized revision of NKI (see OSF)
- Use of `pathlib.Path`
- Added a minimal set of tests for `niworkflows.data.utils._get_data_path`
- Fixed bug when downloading bids examples