### PR TITLE
[HOTFIX] ``LiterateWorkflow`` returning empty desc

### DIFF
--- a/niworkflows/engine/workflows.py
+++ b/niworkflows/engine/workflows.py
@@ -36,8 +36,9 @@ class LiterateWorkflow(pe.Workflow):
         if self.__desc__:
             desc += [self.__desc__]
 
-        for node in pe.utils.topological_sort(self._graph):
+        for node in pe.utils.topological_sort(self._graph)[0]:
             if isinstance(node, LiterateWorkflow):
+                print('%s is literate', node.name)
                 add_desc = node.visit_desc()
                 if add_desc not in desc:
                     desc.append(add_desc)


### PR DESCRIPTION
When migrated from fmriprep, I replaced networkx.topological_sort
with nipype.pipeline.engine.utiles.topological_sort, which does not
have exactly the same interface (basically it wraps the iterable
within a list).