### PR TITLE
FIX: Do not resolve non-existent Paths

### DIFF
--- a/niworkflows/data/utils.py
+++ b/niworkflows/data/utils.py
@@ -167,7 +167,7 @@ def fetch_file(dataset_name, url, dataset_dir, dataset_prefix=None,
                          .format(delta_t, delta_t // 60))
 
     if md5sum is not None:
-        if _md5_sum_file(str(temp_full_path)) != md5sum:
+        if _md5_sum_file(temp_full_path) != md5sum:
             raise ValueError("File {!s} checksum verification has failed."
                              " Dataset fetching aborted.".format(temp_full_path))
 
@@ -292,7 +292,7 @@ def readlinkabs(link):
 def _md5_sum_file(path):
     """ Calculates the MD5 sum of a file.
     """
-    with open(path, 'rb') as fhandle:
+    with Path(path).open('rb') as fhandle:
         md5sum = hashlib.md5()
         while True:
             data = fhandle.read(8192)

--- a/niworkflows/data/utils.py
+++ b/niworkflows/data/utils.py
@@ -116,7 +116,7 @@ def fetch_file(dataset_name, url, dataset_dir, dataset_prefix=None,
         NIWORKFLOWS_LOG.info('Downloading data from %s ...', displayed_url)
     if resume and temp_part_path.exists():
         # Download has been interrupted, we try to resume it.
-        local_file_size = op.getsize(str(temp_part_path))
+        local_file_size = temp_part_path.stat().st_size
         # If the file exists, then only download the remainder
         request.add_header("Range", "bytes={}-".format(local_file_size))
         try:

--- a/niworkflows/data/utils.py
+++ b/niworkflows/data/utils.py
@@ -16,7 +16,6 @@ import time
 import base64
 import hashlib
 import subprocess as sp
-from io import open
 from builtins import str
 
 try:
@@ -31,7 +30,7 @@ from .. import NIWORKFLOWS_LOG
 
 PY3 = sys.version_info[0] > 2
 MAX_RETRIES = 20
-NIWORKFLOWS_CACHE_DIR = (Path.home() / '.cache' / 'stanford-crn')
+NIWORKFLOWS_CACHE_DIR = Path.home() / '.cache' / 'stanford-crn'
 
 
 def fetch_file(dataset_name, url, dataset_dir, dataset_prefix=None,

--- a/niworkflows/data/utils.py
+++ b/niworkflows/data/utils.py
@@ -87,7 +87,7 @@ def fetch_file(dataset_name, url, dataset_dir, dataset_prefix=None,
     temp_part_path = temp_full_path.with_name(file_name + '.part')
 
     if overwrite:
-        shutil.rmtree(dataset_dir, ignore_errors=True)
+        shutil.rmtree(str(dataset_dir), ignore_errors=True)
 
     if overwrite and temp_full_path.exists():
         temp_full_path.unlink()

--- a/niworkflows/data/utils.py
+++ b/niworkflows/data/utils.py
@@ -89,8 +89,8 @@ def fetch_file(dataset_name, url, dataset_dir, dataset_prefix=None,
     if overwrite:
         shutil.rmtree(str(dataset_dir), ignore_errors=True)
 
-    if overwrite and temp_full_path.exists():
-        temp_full_path.unlink()
+        if temp_full_path.exists():
+            temp_full_path.unlink()
 
     t_0 = time.time()
     local_file = None


### PR DESCRIPTION
This PR is an attempt to fix ReadTheDocs builds (see poldracklab/fmriprep#1436).

The line

```Python
NIWORKFLOWS_CACHE_DIR = (Path.home() / '.cache' / 'stanford-crn').resolve()
```

is the primary problem, because, while this path may exist in the docker containers, it does not exist in the RTD environment. It's not clear that it needs to be resolved; this is just `realpath` as opposed to `abspath`, which is not needed to interact with a filesystem logically. Also removed the `.resolve()` from a list of files which are not checked for existence first.

```Python
return [Path(d).expanduser().resolve()
                    for d in data_dir.split(os.pathsep) if d.strip()] or default_dirs
```

Additionally removed the conversions from `Path`s to `str`s in some downstream variables, using `Path` methods instead of `os.path` functions where available.