### PR TITLE
MAINT: Drop more FreeSurfer components

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,8 @@ RUN curl -sSL https://surfer.nmr.mgh.harvard.edu/pub/dist/freesurfer/6.0.1/frees
     --exclude='freesurfer/mni' \
     --exclude='freesurfer/subjects' \
     --exclude='freesurfer/tktools' \
-    --exclude='freesurfer/trctrain'
+    --exclude='freesurfer/trctrain' && \
+    mkdir -p /opt/freesurfer/subjects
 
 ENV FSL_DIR="/usr/share/fsl/5.0" \
     OS="Linux" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,10 +34,14 @@ RUN curl -sSL https://surfer.nmr.mgh.harvard.edu/pub/dist/freesurfer/6.0.1/frees
     --exclude='freesurfer/lib/qt' \
     --exclude='freesurfer/matlab' \
     --exclude='freesurfer/mni' \
-    --exclude='freesurfer/subjects' \
+    --exclude='freesurfer/subjects/*_average' \
+    --exclude='freesurfer/subjects/bert' \
+    --exclude='freesurfer/subjects/cvs_*' \
+    --exclude='freesurfer/subjects/fsaverage?' \
+    --exclude='freesurfer/subjects/fsaverage_sym' \
+    --exclude 'freesurfer/subjects/*.mgz' \
     --exclude='freesurfer/tktools' \
-    --exclude='freesurfer/trctrain' && \
-    mkdir -p /opt/freesurfer/subjects
+    --exclude='freesurfer/trctrain'
 
 ENV FSL_DIR="/usr/share/fsl/5.0" \
     OS="Linux" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,23 +25,17 @@ RUN apt-get update && \
 # Installing freesurfer
 RUN curl -sSL https://surfer.nmr.mgh.harvard.edu/pub/dist/freesurfer/6.0.1/freesurfer-Linux-centos6_x86_64-stable-pub-v6.0.1.tar.gz | tar zxv --no-same-owner -C /opt \
     --exclude='freesurfer/average' \
+    --exclude='freesurfer/data' \
     --exclude='freesurfer/diffusion' \
     --exclude='freesurfer/docs' \
+    --exclude='freesurfer/fsafd' \
     --exclude='freesurfer/fsfast' \
     --exclude='freesurfer/lib/cuda' \
     --exclude='freesurfer/lib/qt' \
     --exclude='freesurfer/matlab' \
-    --exclude='freesurfer/mni/share/man' \
-    --exclude='freesurfer/subjects/fsaverage_sym' \
-    --exclude='freesurfer/subjects/fsaverage3' \
-    --exclude='freesurfer/subjects/fsaverage4' \
-    --exclude='freesurfer/subjects/cvs_avg35' \
-    --exclude='freesurfer/subjects/cvs_avg35_inMNI152' \
-    --exclude='freesurfer/subjects/bert' \
-    --exclude='freesurfer/subjects/lh.EC_average' \
-    --exclude='freesurfer/subjects/rh.EC_average' \
-    --exclude='freesurfer/subjects/sample-*.mgz' \
-    --exclude='freesurfer/subjects/V1_average' \
+    --exclude='freesurfer/mni' \
+    --exclude='freesurfer/subjects' \
+    --exclude='freesurfer/tktools' \
     --exclude='freesurfer/trctrain'
 
 ENV FSL_DIR="/usr/share/fsl/5.0" \


### PR DESCRIPTION
I think for testing niworkflows we only need `bin/` and possibly some `lib/`. Letting Circle decide if I'm right.

Meant to post this against Oscar's branch, but that got merged.