### PR TITLE
CI: Checkout source for coverage reporting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,6 +79,8 @@ jobs:
             - docker-v1-{{ .Branch }}-
             - docker-v1-master-
             - docker-v1-
+      - checkout:
+          path: /tmp/src/niworkflows
       - run:
           name: Load Docker image layer cache
           no_output_timeout: 30m


### PR DESCRIPTION
I think this is the cause of the codecov failures. Should see evidence in the submission steps.