### PR TITLE
[ENH] AROMA plots - add warning for edge cases (none/all are noise)

### DIFF
--- a/niworkflows/tests/test_viz.py
+++ b/niworkflows/tests/test_viz.py
@@ -21,6 +21,7 @@ def test_carpetplot():
         legend=True
     )
 
+
 def test_plot_melodic_components():
     """Test plotting melodic components"""
     import numpy as np
@@ -55,7 +56,7 @@ def test_plot_melodic_components():
     # noise_components
     noise_comps = np.array([1, 2])
     noise_comps_file = os.path.join(os.getcwd(), 'noise_ics.csv')
-    np.savetxt(noise_comps_file, noise_comps, 
+    np.savetxt(noise_comps_file, noise_comps,
                fmt='%i', delimiter=',')
     # in_file
     voxel_ts = np.random.rand(2, 2, 2, 10)

--- a/niworkflows/tests/test_viz.py
+++ b/niworkflows/tests/test_viz.py
@@ -20,3 +20,57 @@ def test_carpetplot():
         output_file=out_file,
         legend=True
     )
+
+def test_plot_melodic_components():
+    """Test plotting melodic components"""
+    import numpy as np
+    # save the artifacts
+    save_artifacts = os.getenv('SAVE_CIRCLE_ARTIFACTS', False)
+    if save_artifacts:
+        all_noise = os.path.join(save_artifacts, 'melodic_all_noise.svg')
+        no_noise = os.path.join(save_artifacts, 'melodic_no_noise.svg')
+    else:
+        all_noise = 'melodic_all_noise.svg'
+        no_noise = 'melodic_no_noise.svg'
+    # melodic directory
+    os.makedirs('melodic', exist_ok=True)
+    melodic_dir = os.path.join(os.getcwd(), "melodic")
+    # melodic_mix
+    mel_mix = np.random.randint(low=-5, high=5, size=[10, 2])
+    mel_mix_file = os.path.join(melodic_dir, "melodic_mix")
+    np.savetxt(mel_mix_file, mel_mix, fmt='%i')
+    # melodic_FTmix
+    mel_ftmix = np.random.rand(2, 5)
+    mel_ftmix_file = os.path.join(melodic_dir, "melodic_FTmix")
+    np.savetxt(mel_ftmix_file, mel_ftmix)
+    # melodic_ICstats
+    mel_icstats = np.random.rand(2, 2)
+    mel_icstats_file = os.path.join(melodic_dir, "melodic_ICstats")
+    np.savetxt(mel_icstats_file, mel_icstats)
+    # melodic_IC
+    mel_ic = np.random.rand(2, 2, 2, 2)
+    mel_ic_file = os.path.join(melodic_dir, "melodic_IC.nii.gz")
+    mel_ic_img = nb.Nifti2Image(mel_ic, np.eye(4))
+    mel_ic_img.to_filename(mel_ic_file)
+    # noise_components
+    noise_comps = np.array([1, 2])
+    noise_comps_file = os.path.join(os.getcwd(), 'noise_ics.csv')
+    np.savetxt(noise_comps_file, noise_comps, 
+               fmt='%i', delimiter=',')
+    # in_file
+    voxel_ts = np.random.rand(2, 2, 2, 10)
+    in_file = nb.Nifti2Image(voxel_ts, np.eye(4))
+    in_file.to_filename('in_file.nii.gz')
+    # report_mask
+    report_mask = nb.Nifti2Image(np.ones([2, 2, 2]), np.eye(4))
+    report_mask.to_filename('report_mask.nii.gz')
+    print(os.getcwd())
+    # run command with all noise components
+    viz.utils.plot_melodic_components(melodic_dir, 'in_file.nii.gz', tr=2.0,
+                                      report_mask='report_mask.nii.gz',
+                                      noise_components_file=noise_comps_file,
+                                      out_file=all_noise)
+    # run command with no noise components
+    viz.utils.plot_melodic_components(melodic_dir, 'in_file.nii.gz', tr=2.0,
+                                      report_mask='report_mask.nii.gz',
+                                      out_file=no_noise)

--- a/niworkflows/viz/utils.py
+++ b/niworkflows/viz/utils.py
@@ -538,16 +538,21 @@ def plot_melodic_components(melodic_dir, in_file, tr=None,
     Ny = Fs / 2
     f = Ny * (np.array(list(range(1, power.shape[0] + 1)))) / (power.shape[0])
 
+    noise_components = None
+    if noise_components_file:
+        noise_components = np.loadtxt(noise_components_file,
+                                      dtype=int, delimiter=',', ndmin=1)
+
     n_rows = int((n_components + (n_components % 2)) / 2)
     fig = plt.figure(figsize=(6.5 * 1.5, n_rows * 0.85))
     gs = GridSpec(n_rows * 2, 9,
                   width_ratios=[1, 1, 1, 4, 0.001, 1, 1, 1, 4, ],
                   height_ratios=[1.1, 1] * n_rows)
 
-    noise_components = None
-    if noise_components_file:
-        noise_components = np.loadtxt(noise_components_file,
-                                      dtype=int, delimiter=',', ndmin=1)
+    if noise_components.size == n_components:
+        fig.suptitle("WARNING: ALL COMPONENTS CLASSIFIED AS NOISE", color='r')
+    elif noise_components is None or noise_components.size == 0:
+        fig.suptitle("WARNING: NO COMPONENTS CLASSIFIED AS NOISE", color='r')
 
     for i, img in enumerate(
             iter_img(os.path.join(melodic_dir, "melodic_IC.nii.gz"))):

--- a/niworkflows/viz/utils.py
+++ b/niworkflows/viz/utils.py
@@ -548,11 +548,10 @@ def plot_melodic_components(melodic_dir, in_file, tr=None,
     gs = GridSpec(n_rows * 2, 9,
                   width_ratios=[1, 1, 1, 4, 0.001, 1, 1, 1, 4, ],
                   height_ratios=[1.1, 1] * n_rows)
-
-    if noise_components.size == n_components:
-        fig.suptitle("WARNING: ALL COMPONENTS CLASSIFIED AS NOISE", color='r')
-    elif noise_components is None or noise_components.size == 0:
+    if noise_components is None or noise_components.size == 0:
         fig.suptitle("WARNING: NO COMPONENTS CLASSIFIED AS NOISE", color='r')
+    elif noise_components.size == n_components:
+        fig.suptitle("WARNING: ALL COMPONENTS CLASSIFIED AS NOISE", color='r')
 
     for i, img in enumerate(
             iter_img(os.path.join(melodic_dir, "melodic_IC.nii.gz"))):

--- a/niworkflows/viz/utils.py
+++ b/niworkflows/viz/utils.py
@@ -544,21 +544,36 @@ def plot_melodic_components(melodic_dir, in_file, tr=None,
                                       dtype=int, delimiter=',', ndmin=1)
 
     n_rows = int((n_components + (n_components % 2)) / 2)
-    fig = plt.figure(figsize=(6.5 * 1.5, n_rows * 0.85))
-    gs = GridSpec(n_rows * 2, 9,
+    warning_row = int(noise_components is None or
+                      noise_components.size == 0 or
+                      noise_components.size == n_components)
+    fig = plt.figure(figsize=(6.5 * 1.5, (n_rows + warning_row) * 0.85))
+    gs = GridSpec(n_rows * 2 + warning_row, 9,
                   width_ratios=[1, 1, 1, 4, 0.001, 1, 1, 1, 4, ],
-                  height_ratios=[1.1, 1] * n_rows)
-    if noise_components is None or noise_components.size == 0:
-        fig.suptitle("WARNING: NO COMPONENTS CLASSIFIED AS NOISE", color='r')
-    elif noise_components.size == n_components:
-        fig.suptitle("WARNING: ALL COMPONENTS CLASSIFIED AS NOISE", color='r')
+                  height_ratios=[5] * warning_row + [1.1, 1] * n_rows)
+
+    if warning_row:
+        ax = fig.add_subplot(gs[0, :])
+        ncomps = 'NONE of the'
+        if noise_components is not None and noise_components.size == n_components:
+            ncomps = 'ALL'
+        ax.annotate(
+            'WARNING: {} components were classified as noise'.format(ncomps),
+            xy=(0.0, 0.5), xycoords='axes fraction',
+            xytext=(0.01, 0.5), textcoords='axes fraction',
+            size=12, color='#ea8800',
+            bbox=dict(boxstyle="round",
+                      fc='#f7dcb7',
+                      ec='#FC990E'))
+        ax.axes.get_xaxis().set_visible(False)
+        ax.axes.get_yaxis().set_visible(False)
 
     for i, img in enumerate(
             iter_img(os.path.join(melodic_dir, "melodic_IC.nii.gz"))):
 
         col = i % 2
         row = int(i / 2)
-        l_row = row * 2
+        l_row = row * 2 + warning_row
 
         # Set default colors
         color_title = 'k'


### PR DESCRIPTION
per @oesteban's [comment](https://github.com/poldracklab/fmriprep/pull/1467#issuecomment-457018934), this pull request attempts to add a warning to the figure if all components are listed as either signal or noise.
references poldracklab/fmriprep#1467

However, I must be needing to improve my matplotlib since even with this addition the warning does not appear to be displayed in the fmriprep reports.