### PR TITLE
CI: MD5 license to verify contents

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,6 +97,7 @@ jobs:
           command: |
             mkdir -p /tmp/fslicense
             printf "$FS_LICENSE_CONTENT" | base64 -d  >> /tmp/fslicense/license.txt
+            md5sum /tmp/fslicense/license.txt
       - run:
           name: Set PR number
           command: |


### PR DESCRIPTION
The goal of this is to help debug situations like #292, which I suspect is a result of the license file not being properly made for PRs.