### PR TITLE
[HOTFIX] Only check headers of NIfTI files

### DIFF
--- a/niworkflows/interfaces/bids.py
+++ b/niworkflows/interfaces/bids.py
@@ -266,6 +266,9 @@ desc-preproc_bold.nii.gz'
             is_nii = out_file.endswith('.nii') or out_file.endswith('.nii.gz')
             if self.inputs.check_hdr and is_nii:
                 nii = nb.load(out_file)
+                if not isinstance(nii, (nb.Nifti1Image, nb.Nifti2Image)):
+                    # .dtseries.nii are CIfTI2, therefore skip check
+                    return runtime
                 hdr = nii.header.copy()
                 curr_units = tuple([None if u == 'unknown' else u
                                     for u in hdr.get_xyzt_units()])
@@ -287,7 +290,6 @@ desc-preproc_bold.nii.gz'
                     # Rewrite file with new header
                     nii.__class__(nii.get_data(), nii.affine, hdr).to_filename(
                         out_file)
-
         return runtime
 
 


### PR DESCRIPTION
We are writing CIfTI2 timeseries with extension .dtseries.nii. They break the DerivativesDataSink.