### PR TITLE
[FIX] Scaling of confound fix

### DIFF
--- a/niworkflows/viz/plots.py
+++ b/niworkflows/viz/plots.py
@@ -479,7 +479,8 @@ def confoundplot(tseries, gs_ts, gs_dist=None, name=None,
     nonnan = tseries[~np.isnan(tseries)]
     if nonnan.size > 0:
         # Calculate Y limits
-        def_ylims = [nonnan.min() - 0.1 * abs(nonnan.min()), 1.1 * nonnan.max()]
+        valrange = (nonnan.max() - nonnan.min())
+        def_ylims = [nonnan.min() - 0.1 * nonnan_range, nonnan.max() + 0.1 * nonnan_range]
         if ylims is not None:
             if ylims[0] is not None:
                 def_ylims[0] = min([def_ylims[0], ylims[0]])
@@ -539,7 +540,7 @@ def confoundplot(tseries, gs_ts, gs_dist=None, name=None,
         ax_dist = plt.subplot(gs_dist)
         sns.displot(tseries, vertical=True, ax=ax_dist)
         ax_dist.set_xlabel('Timesteps')
-        ax_dist.set_ylim(ax_ts.get_ylim())
+        ax_dist.set_ylim([])
         ax_dist.set_yticklabels([])
 
         return [ax_ts, ax_dist], gs

--- a/niworkflows/viz/plots.py
+++ b/niworkflows/viz/plots.py
@@ -540,7 +540,7 @@ def confoundplot(tseries, gs_ts, gs_dist=None, name=None,
         ax_dist = plt.subplot(gs_dist)
         sns.displot(tseries, vertical=True, ax=ax_dist)
         ax_dist.set_xlabel('Timesteps')
-        ax_dist.set_ylim([])
+        ax_dist.set_ylim(ax_ts.get_ylim())
         ax_dist.set_yticklabels([])
 
         return [ax_ts, ax_dist], gs

--- a/niworkflows/viz/plots.py
+++ b/niworkflows/viz/plots.py
@@ -480,7 +480,7 @@ def confoundplot(tseries, gs_ts, gs_dist=None, name=None,
     if nonnan.size > 0:
         # Calculate Y limits
         valrange = (nonnan.max() - nonnan.min())
-        def_ylims = [nonnan.min() - 0.1 * nonnan_range, nonnan.max() + 0.1 * nonnan_range]
+        def_ylims = [nonnan.min() - 0.1 * valrange, nonnan.max() + 0.1 * valrange]
         if ylims is not None:
             if ylims[0] is not None:
                 def_ylims[0] = min([def_ylims[0], ylims[0]])


### PR DESCRIPTION
Realized I forgot to submit this. 

Fixing the scaling issue in #242. 

Scales the confounds based on the range of the values rather than scaling the min and max. 

if min value was 2 and max value was 5:
Before. ylim: 1.8 - 5.5 (plot displayed in 81% of ylim range)
Now, ylim: 1.7 - 5.3 (plot displayed in 83% of ylim range)

if min value was 900 and max value was 1000:
Before, ylim: 810 - 1100 (plot displayed in 34% of ylim range <- when squashing was occurring)
Now, ylim: 890 - 1010 (plot displayed in 83% of ylim range)

