### PR TITLE
ENH: ``DerivativesDataSink`` - enable JSON sidecar writing

### DIFF
--- a/niworkflows/interfaces/bids.py
+++ b/niworkflows/interfaces/bids.py
@@ -229,24 +229,25 @@ class BIDSDataGrabber(SimpleInterface):
         return runtime
 
 
-class DerivativesDataSinkInputSpec(BaseInterfaceInputSpec):
+class DerivativesDataSinkInputSpec(DynamicTraitedSpec, BaseInterfaceInputSpec):
     base_directory = traits.Directory(
         desc='Path to the base directory for storing data.')
-    in_file = InputMultiObject(File(exists=True), mandatory=True,
-                               desc='the object to be saved')
-    source_file = File(exists=False, mandatory=True, desc='the input func file')
-    space = Str('', usedefault=True, desc='Label for space field')
-    desc = Str('', usedefault=True, desc='Label for description field')
-    suffix = Str('', usedefault=True, desc='suffix appended to source_file')
-    keep_dtype = traits.Bool(False, usedefault=True, desc='keep datatype suffix')
-    extra_values = traits.List(Str)
+    check_hdr = traits.Bool(True, usedefault=True, desc='fix headers of NIfTI outputs')
     compress = traits.Bool(desc="force compression (True) or uncompression (False)"
                                 " of the output file (default: same as input)")
-    check_hdr = traits.Bool(True, usedefault=True, desc='fix headers of NIfTI outputs')
+    desc = Str('', usedefault=True, desc='Label for description field')
+    extra_values = traits.List(Str)
+    in_file = InputMultiObject(File(exists=True), mandatory=True,
+                               desc='the object to be saved')
+    keep_dtype = traits.Bool(False, usedefault=True, desc='keep datatype suffix')
+    source_file = File(exists=False, mandatory=True, desc='the input func file')
+    space = Str('', usedefault=True, desc='Label for space field')
+    suffix = Str('', usedefault=True, desc='suffix appended to source_file')
 
 
 class DerivativesDataSinkOutputSpec(TraitedSpec):
     out_file = OutputMultiObject(File(exists=True, desc='written file path'))
+    out_meta = OutputMultiObject(File(exists=True, desc='written JSON sidecar path'))
     compression = OutputMultiObject(
         traits.Bool, desc='whether ``in_file`` was compressed/uncompressed '
                           'or `it was copied directly.')

--- a/niworkflows/interfaces/bids.py
+++ b/niworkflows/interfaces/bids.py
@@ -8,6 +8,7 @@ Interfaces for handling BIDS-like neuroimaging structures
 """
 
 import os
+from json import dumps
 from pathlib import Path
 from shutil import copytree, rmtree
 
@@ -287,6 +288,24 @@ class DerivativesDataSink(SimpleInterface):
     '.../niworkflows/sub-02/ses-noanat/func/sub-02_ses-noanat_task-rest_run-01_\
 desc-preproc_bold.nii.gz'
 
+    >>> bids_dir = tmpdir / 'bidsroot' / 'sub-02' / 'ses-noanat' / 'func'
+    >>> bids_dir.mkdir(parents=True, exist_ok=True)
+    >>> tricky_source = bids_dir / 'sub-02_ses-noanat_task-rest_run-01_bold.nii.gz'
+    >>> tricky_source.open('w').close()
+    >>> dsink = DerivativesDataSink(base_directory=str(tmpdir), check_hdr=False)
+    >>> dsink.inputs.in_file = str(tmpfile)
+    >>> dsink.inputs.source_file = str(tricky_source)
+    >>> dsink.inputs.keep_dtype = True
+    >>> dsink.inputs.desc = 'preproc'
+    >>> dsink.inputs.RepetitionTime = 0.75
+    >>> res = dsink.run()
+    >>> res.outputs.out_meta  # doctest: +ELLIPSIS
+    '.../niworkflows/sub-02/ses-noanat/func/sub-02_ses-noanat_task-rest_run-01_\
+desc-preproc_bold.json'
+
+    >>> Path(res.outputs.out_meta).read_text().splitlines()[1]
+    '  "RepetitionTime": 0.75'
+
     """
     input_spec = DerivativesDataSinkInputSpec
     output_spec = DerivativesDataSinkOutputSpec
@@ -294,6 +313,11 @@ desc-preproc_bold.nii.gz'
     _always_run = True
 
     def __init__(self, out_path_base=None, **inputs):
+        self._metadata = {}
+        self._static_traits = self.input_spec.class_editable_traits()
+        for dynamic_input in set(inputs) - set(self._static_traits):
+            self._metadata[dynamic_input] = inputs.pop(dynamic_input)
+
         super(DerivativesDataSink, self).__init__(**inputs)
         self._results['out_file'] = []
         if out_path_base:
@@ -382,6 +406,16 @@ desc-preproc_bold.nii.gz'
                     # Rewrite file with new header
                     nii.__class__(nii.get_data(), nii.affine, hdr).to_filename(
                         out_file)
+
+        if len(self._results['out_file']) == 1:
+            meta_fields = self.inputs.copyable_trait_names()
+            meta_dict = {k: getattr(self.inputs, k)
+                         for k in meta_fields if k not in self._static_traits}
+            if meta_dict:
+                sidecar = (Path(self._results['out_file'][0]).parent /
+                           ('%s.json' % _splitext(self._results['out_file'][0])[0]))
+                sidecar.write_text(dumps(meta_dict, sort_keys=True, indent=2))
+                self._results['out_meta'] = str(sidecar)
         return runtime
 
 


### PR DESCRIPTION
This PR makes the input spec of `DerivativesDataSink` dynamic. Those inputs set dynamically are considered metadata entries and stored to a sidecar JSON, if a single output file was sunk. If the output is more than one file metadata is dismissed (we may consider how to tackle multi-outputs in the future).

Close #308, enables poldracklab/fmriprep#1190, poldracklab/fmriprep#1384, poldracklab/smriprep#6