### PR TITLE
ENH: Add several helper interfaces

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -157,7 +157,7 @@ RUN pip install --no-cache-dir "templateflow>=0.1.0,<0.2.0a0" && \
 # Installing dev requirements (packages that are not in pypi)
 WORKDIR /src/
 COPY requirements.txt requirements.txt
-RUN pip install -r requirements.txt && \
+RUN pip install --no-cache-dir -r requirements.txt && \
     rm -rf ~/.cache/pip
 
 COPY . niworkflows/
@@ -167,7 +167,7 @@ RUN echo "${VERSION}" > /src/niworkflows/niworkflows/VERSION && \
     echo "include niworkflows/VERSION" >> MANIFEST.in && \
     find /src/niworkflows/ -name "test*.py" -exec chmod a-x {} + && \
     cd /src/niworkflows && \
-    pip install .[all] && \
+    pip install --no-cache-dir .[all] && \
     rm -rf ~/.cache/pip
 
 # Final settings

--- a/niworkflows/__about__.py
+++ b/niworkflows/__about__.py
@@ -69,7 +69,9 @@ REQUIRES = [
 SETUP_REQUIRES = []
 REQUIRES += SETUP_REQUIRES
 
-LINKS_REQUIRES = []
+LINKS_REQUIRES = [
+    'git+https://github.com/daavoo/pyntcloud#egg=pyntcloud-0.0.1',
+]
 TESTS_REQUIRES = [
     'pytest',
     'pytest-xdist',
@@ -84,6 +86,7 @@ EXTRA_REQUIRES = {
         'pydot>=1.2.3',
     ],
     'duecredit': ['duecredit'],
+    'pointclouds': ['pyntcloud'],
     'tests': TESTS_REQUIRES,
 }
 

--- a/niworkflows/interfaces/ants.py
+++ b/niworkflows/interfaces/ants.py
@@ -474,9 +474,11 @@ class AntsJointFusion(ANTSCommand):
             ])
             retval = target_image_cmd
         elif opt == 'atlas_segmentation_image':
-            assert len(val) == len(self.inputs.atlas_image), "Number of specified " \
-                "segmentations should be identical to the number of atlas image " \
-                "sets {0}!={1}".format(len(val), len(self.inputs.atlas_image))
+            if len(val) != len(self.inputs.atlas_image):
+                raise ValueError(
+                    "Number of specified segmentations should be identical to the number "
+                    "of atlas image sets {0}!={1}".format(
+                        len(val), len(self.inputs.atlas_image)))
 
             atlas_segmentation_image_cmd = " ".join([
                 '-l {0}'.format(fn)

--- a/niworkflows/interfaces/ants.py
+++ b/niworkflows/interfaces/ants.py
@@ -7,6 +7,7 @@ Nipype interfaces for ANTs commands
 """
 
 import os
+from glob import glob
 from nipype.interfaces import base
 from nipype.interfaces.ants.base import ANTSCommandInputSpec, ANTSCommand
 from nipype.interfaces.base import traits, isdefined
@@ -281,3 +282,230 @@ class AI(ANTSCommand):
 
     def _list_outputs(self):
         return getattr(self, '_output')
+
+
+class AntsJointFusionInputSpec(ANTSCommandInputSpec):
+    dimension = traits.Enum(
+        3,
+        2,
+        4,
+        argstr='-d %d',
+        desc='This option forces the image to be treated '
+        'as a specified-dimensional image. If not '
+        'specified, the program tries to infer the '
+        'dimensionality from the input image.')
+    target_image = traits.List(
+        base.InputMultiPath(base.File(exists=True)),
+        argstr='-t %s',
+        mandatory=True,
+        desc='The target image (or '
+        'multimodal target images) assumed to be '
+        'aligned to a common image domain.')
+    atlas_image = traits.List(
+        base.InputMultiPath(base.File(exists=True)),
+        argstr="-g %s...",
+        mandatory=True,
+        desc='The atlas image (or '
+        'multimodal atlas images) assumed to be '
+        'aligned to a common image domain.')
+    atlas_segmentation_image = base.InputMultiPath(
+        base.File(exists=True),
+        argstr="-l %s...",
+        mandatory=True,
+        desc='The atlas segmentation '
+        'images. For performing label fusion the number '
+        'of specified segmentations should be identical '
+        'to the number of atlas image sets.')
+    alpha = traits.Float(
+        default_value=0.1,
+        usedefault=True,
+        argstr='-a %s',
+        desc=(
+            'Regularization '
+            'term added to matrix Mx for calculating the inverse. Default = 0.1'
+        ))
+    beta = traits.Float(
+        default_value=2.0,
+        usedefault=True,
+        argstr='-b %s',
+        desc=('Exponent for mapping '
+              'intensity difference to the joint error. Default = 2.0'))
+    retain_label_posterior_images = traits.Bool(
+        False,
+        argstr='-r',
+        usedefault=True,
+        requires=['atlas_segmentation_image'],
+        desc=('Retain label posterior probability images. Requires '
+              'atlas segmentations to be specified. Default = false'))
+    retain_atlas_voting_images = traits.Bool(
+        False,
+        argstr='-f',
+        usedefault=True,
+        desc=('Retain atlas voting images. Default = false'))
+    constrain_nonnegative = traits.Bool(
+        False,
+        argstr='-c',
+        usedefault=True,
+        desc=('Constrain solution to non-negative weights.'))
+    patch_radius = traits.ListInt(
+        minlen=3,
+        maxlen=3,
+        argstr='-p %s',
+        desc=('Patch radius for similarity measures.'
+              'Default: 2x2x2'))
+    patch_metric = traits.Enum(
+        'PC',
+        'MSQ',
+        argstr='-m %s',
+        desc=('Metric to be used in determining the most similar '
+              'neighborhood patch. Options include Pearson\'s '
+              'correlation (PC) and mean squares (MSQ). Default = '
+              'PC (Pearson correlation).'))
+    search_radius = traits.List(
+        [3, 3, 3],
+        minlen=1,
+        maxlen=3,
+        argstr='-s %s',
+        usedefault=True,
+        desc=('Search radius for similarity measures. Default = 3x3x3. '
+              'One can also specify an image where the value at the '
+              'voxel specifies the isotropic search radius at that voxel.'))
+    exclusion_image_label = traits.List(
+        traits.Str(),
+        argstr='-e %s',
+        requires=['exclusion_image'],
+        desc=('Specify a label for the exclusion region.'))
+    exclusion_image = traits.List(
+        base.File(exists=True),
+        desc=('Specify an exclusion region for the given label.'))
+    mask_image = base.File(
+        argstr='-x %s',
+        exists=True,
+        desc='If a mask image '
+        'is specified, fusion is only performed in the mask region.')
+    out_label_fusion = base.File(
+        argstr="%s", hash_files=False, desc='The output label fusion image.')
+    out_intensity_fusion_name_format = traits.Str(
+        argstr="",
+        desc='Optional intensity fusion '
+        'image file name format. '
+        '(e.g. "antsJointFusionIntensity_%d.nii.gz")')
+    out_label_post_prob_name_format = traits.Str(
+        'antsJointFusionPosterior_%d.nii.gz',
+        requires=['out_label_fusion', 'out_intensity_fusion_name_format'],
+        desc='Optional label posterior probability '
+        'image file name format.')
+    out_atlas_voting_weight_name_format = traits.Str(
+        'antsJointFusionVotingWeight_%d.nii.gz',
+        requires=[
+            'out_label_fusion', 'out_intensity_fusion_name_format',
+            'out_label_post_prob_name_format'
+        ],
+        desc='Optional atlas voting weight image '
+        'file name format.')
+    verbose = traits.Bool(False, argstr="-v", desc=('Verbose output.'))
+
+
+class AntsJointFusionOutputSpec(base.TraitedSpec):
+    out_label_fusion = base.File(exists=True)
+    out_intensity_fusion = base.OutputMultiPath(
+        base.File(exists=True))
+    out_label_post_prob = base.OutputMultiPath(
+        base.File(exists=True))
+    out_atlas_voting_weight = base.OutputMultiPath(
+        base.File(exists=True))
+
+
+class AntsJointFusion(ANTSCommand):
+    """
+    """
+    input_spec = AntsJointFusionInputSpec
+    output_spec = AntsJointFusionOutputSpec
+    _cmd = 'antsJointFusion'
+
+    def _format_arg(self, opt, spec, val):
+        if opt == 'exclusion_image_label':
+            retval = []
+            for ii in range(len(self.inputs.exclusion_image_label)):
+                retval.append(
+                    '-e {0}[{1}]'.format(self.inputs.exclusion_image_label[ii],
+                                         self.inputs.exclusion_image[ii]))
+            retval = ' '.join(retval)
+        elif opt == 'patch_radius':
+            retval = '-p {0}'.format(self._format_xarray(val))
+        elif opt == 'search_radius':
+            retval = '-s {0}'.format(self._format_xarray(val))
+        elif opt == 'out_label_fusion':
+            if isdefined(self.inputs.out_intensity_fusion_name_format):
+                if isdefined(self.inputs.out_label_post_prob_name_format):
+                    if isdefined(
+                            self.inputs.out_atlas_voting_weight_name_format):
+                        retval = '-o [{0}, {1}, {2}, {3}]'.format(
+                            self.inputs.out_label_fusion,
+                            self.inputs.out_intensity_fusion_name_format,
+                            self.inputs.out_label_post_prob_name_format,
+                            self.inputs.out_atlas_voting_weight_name_format)
+                    else:
+                        retval = '-o [{0}, {1}, {2}]'.format(
+                            self.inputs.out_label_fusion,
+                            self.inputs.out_intensity_fusion_name_format,
+                            self.inputs.out_label_post_prob_name_format)
+                else:
+                    retval = '-o [{0}, {1}]'.format(
+                        self.inputs.out_label_fusion,
+                        self.inputs.out_intensity_fusion_name_format)
+            else:
+                retval = '-o {0}'.format(self.inputs.out_label_fusion)
+        elif opt == 'out_intensity_fusion_name_format':
+            retval = ''
+            if not isdefined(self.inputs.out_label_fusion):
+                retval = '-o {0}'.format(
+                    self.inputs.out_intensity_fusion_name_format)
+        elif opt == 'atlas_image':
+            atlas_image_cmd = " ".join([
+                '-g [{0}]'.format(", ".join("'%s'" % fn for fn in ai))
+                for ai in self.inputs.atlas_image
+            ])
+            retval = atlas_image_cmd
+        elif opt == 'target_image':
+            target_image_cmd = " ".join([
+                '-t [{0}]'.format(", ".join("'%s'" % fn for fn in ai))
+                for ai in self.inputs.target_image
+            ])
+            retval = target_image_cmd
+        elif opt == 'atlas_segmentation_image':
+            assert len(val) == len(self.inputs.atlas_image), "Number of specified " \
+                "segmentations should be identical to the number of atlas image " \
+                "sets {0}!={1}".format(len(val), len(self.inputs.atlas_image))
+
+            atlas_segmentation_image_cmd = " ".join([
+                '-l {0}'.format(fn)
+                for fn in self.inputs.atlas_segmentation_image
+            ])
+            retval = atlas_segmentation_image_cmd
+        else:
+
+            return super(AntsJointFusion, self)._format_arg(opt, spec, val)
+        return retval
+
+    def _list_outputs(self):
+        outputs = self._outputs().get()
+        if isdefined(self.inputs.out_label_fusion):
+            outputs['out_label_fusion'] = os.path.abspath(
+                self.inputs.out_label_fusion)
+        if isdefined(self.inputs.out_intensity_fusion_name_format):
+            outputs['out_intensity_fusion'] = glob(os.path.abspath(
+                self.inputs.out_intensity_fusion_name_format.replace(
+                    '%d', '*'))
+            )
+        if isdefined(self.inputs.out_label_post_prob_name_format):
+            outputs['out_label_post_prob'] = glob(os.path.abspath(
+                self.inputs.out_label_post_prob_name_format.replace(
+                    '%d', '*'))
+            )
+        if isdefined(self.inputs.out_atlas_voting_weight_name_format):
+            outputs['out_atlas_voting_weight'] = glob(os.path.abspath(
+                self.inputs.out_atlas_voting_weight_name_format.replace(
+                    '%d', '*'))
+            )
+        return outputs

--- a/niworkflows/interfaces/surf.py
+++ b/niworkflows/interfaces/surf.py
@@ -527,7 +527,6 @@ def ply2gii(in_file, metadata, out_file=None):
     from nibabel.gifti import (
         GiftiMetaData, GiftiCoordSystem, GiftiImage, GiftiDataArray,
     )
-    from nipype.utils.filemanip import fname_presuffix
     from pyntcloud import PyntCloud
 
     in_file = Path(in_file)

--- a/niworkflows/interfaces/surf.py
+++ b/niworkflows/interfaces/surf.py
@@ -14,6 +14,7 @@ from collections import defaultdict
 import numpy as np
 import nibabel as nb
 
+from nipype.utils.filemanip import fname_presuffix
 from nipype.interfaces.base import (
     BaseInterfaceInputSpec, TraitedSpec, File, traits, isdefined,
     SimpleInterface, CommandLine, CommandLineInputSpec,
@@ -247,8 +248,8 @@ class CSVToGiftiOutputSpec(TraitedSpec):
 
 
 class CSVToGifti(SimpleInterface):
-    """Converts GIfTI files to CSV to make them ammenable to use with
-    ``antsApplyTransformsToPoints``."""
+    """Converts CSV files back to GIfTI, after moving vertices with
+    ``antsApplyTransformToPoints``."""
     input_spec = CSVToGiftiInputSpec
     output_spec = CSVToGiftiOutputSpec
 
@@ -314,8 +315,10 @@ class PoissonReconOutputSpec(TraitedSpec):
 
 
 class PoissonRecon(CommandLine):
-    """Converts multiple surfaces into a pointcloud with corresponding normals
-    to then apply Poisson reconstruction"""
+    """Runs Poisson Reconstruction on a cloud of points + normals
+    given in PLY format.
+    See https://github.com/mkazhdan/PoissonRecon
+    """
     input_spec = PoissonReconInputSpec
     output_spec = PoissonReconOutputSpec
     _cmd = 'PoissonRecon'
@@ -331,8 +334,7 @@ class PLYtoGiftiOutputSpec(TraitedSpec):
 
 
 class PLYtoGifti(SimpleInterface):
-    """Converts multiple surfaces into a pointcloud with corresponding normals
-    to then apply Poisson reconstruction"""
+    """Convert surfaces from PLY to GIfTI"""
     input_spec = PLYtoGiftiInputSpec
     output_spec = PLYtoGiftiOutputSpec
 
@@ -385,8 +387,7 @@ class UnzipJoinedSurfacesOutputSpec(TraitedSpec):
 
 
 class UnzipJoinedSurfaces(SimpleInterface):
-    """Converts multiple surfaces into a pointcloud with corresponding normals
-    to then apply Poisson reconstruction"""
+    """Unpack surfaces by identifier keys"""
     input_spec = UnzipJoinedSurfacesInputSpec
     output_spec = UnzipJoinedSurfacesOutputSpec
 
@@ -481,7 +482,6 @@ def load_transform(fname):
         return np.genfromtxt(lines)
 
     raise ValueError("Unknown transform type; pass FSL (.mat) or LTA (.lta)")
-
 
 
 def vertex_normals(vertices, faces):

--- a/niworkflows/interfaces/surf.py
+++ b/niworkflows/interfaces/surf.py
@@ -9,14 +9,22 @@ Handling surfaces
 """
 import os
 import re
+from collections import defaultdict
 
 import numpy as np
 import nibabel as nb
 
 from nipype.interfaces.base import (
     BaseInterfaceInputSpec, TraitedSpec, File, traits, isdefined,
-    SimpleInterface
+    SimpleInterface, CommandLine, CommandLineInputSpec,
+    InputMultiPath, OutputMultiPath,
 )
+
+SECONDARY_ANAT_STRUC = {
+    'smoothwm': 'GrayWhite',
+    'pial': 'Pial',
+    'midthickness': 'GrayMid'
+}
 
 
 class NormalizeSurfInputSpec(BaseInterfaceInputSpec):
@@ -189,6 +197,214 @@ class GiftiSetAnatomicalStructure(SimpleInterface):
         return runtime
 
 
+class GiftiToCSVInputSpec(BaseInterfaceInputSpec):
+    in_file = File(mandatory=True, exists=True, desc='GIFTI file')
+    itk_lps = traits.Bool(False, usedefault=True, desc='flip XY axes')
+
+
+class GiftiToCSVOutputSpec(TraitedSpec):
+    out_file = File(desc='output csv file')
+
+
+class GiftiToCSV(SimpleInterface):
+    """Converts GIfTI files to CSV to make them ammenable to use with
+    ``antsApplyTransformsToPoints``."""
+    input_spec = GiftiToCSVInputSpec
+    output_spec = GiftiToCSVOutputSpec
+
+    def _run_interface(self, runtime):
+        gii = nb.load(self.inputs.in_file)
+        data = gii.darrays[0].data
+
+        if self.inputs.itk_lps:  # ITK: flip X and Y around 0
+            data[:, :2] *= -1
+
+        # antsApplyTransformsToPoints requires 5 cols with headers
+        csvdata = np.hstack((data, np.zeros((data.shape[0], 3))))
+
+        out_file = fname_presuffix(
+            self.inputs.in_file,
+            newpath=runtime.cwd,
+            use_ext=False,
+            suffix='points.csv')
+        np.savetxt(
+            out_file, csvdata,
+            delimiter=',',
+            header='x,y,z,t,label,comment',
+            fmt=['%.5f'] * 4 + ['%d'] * 2)
+        self._results['out_file'] = out_file
+        return runtime
+
+
+class CSVToGiftiInputSpec(BaseInterfaceInputSpec):
+    in_file = File(mandatory=True, exists=True, desc='CSV file')
+    gii_file = File(mandatory=True, exists=True, desc='reference GIfTI file')
+    itk_lps = traits.Bool(False, usedefault=True, desc='flip XY axes')
+
+
+class CSVToGiftiOutputSpec(TraitedSpec):
+    out_file = File(desc='output GIfTI file')
+
+
+class CSVToGifti(SimpleInterface):
+    """Converts GIfTI files to CSV to make them ammenable to use with
+    ``antsApplyTransformsToPoints``."""
+    input_spec = CSVToGiftiInputSpec
+    output_spec = CSVToGiftiOutputSpec
+
+    def _run_interface(self, runtime):
+        gii = nb.load(self.inputs.gii_file)
+        data = np.loadtxt(self.inputs.in_file, delimiter=',',
+                          skiprows=1, usecols=(0, 1, 2))
+
+        if self.inputs.itk_lps:  # ITK: flip X and Y around 0
+            data[:, :2] *= -1
+
+        gii.darrays[0].data = data[:, :3].astype(
+            gii.darrays[0].data.dtype)
+        out_file = fname_presuffix(
+            self.inputs.gii_file,
+            newpath=runtime.cwd,
+            suffix='.transformed')
+        gii.to_filename(out_file)
+        self._results['out_file'] = out_file
+        return runtime
+
+
+class SurfacesToPointCloudInputSpec(BaseInterfaceInputSpec):
+    in_files = InputMultiPath(File(exists=True), mandatory=True,
+                              desc='input GIfTI files')
+    out_file = File('pointcloud.ply', usedefault=True,
+                    desc='output file name')
+
+
+class SurfacesToPointCloudOutputSpec(TraitedSpec):
+    out_file = File(desc='output pointcloud in PLY format')
+
+
+class SurfacesToPointCloud(SimpleInterface):
+    """Converts multiple surfaces into a pointcloud with corresponding normals
+    to then apply Poisson reconstruction"""
+    input_spec = SurfacesToPointCloudInputSpec
+    output_spec = SurfacesToPointCloudOutputSpec
+
+    def _run_interface(self, runtime):
+        from pathlib import Path
+
+        giis = [nb.load(g) for g in self.inputs.in_files]
+        vertices = np.vstack([g.darrays[0].data for g in giis])
+        norms = np.vstack([vertex_normals(
+            g.darrays[0].data, g.darrays[1].data) for g in giis])
+        out_file = Path(self.inputs.out_file).resolve()
+        pointcloud2ply(vertices, norms, out_file=out_file)
+        self._results['out_file'] = str(out_file)
+        return runtime
+
+
+class PoissonReconInputSpec(CommandLineInputSpec):
+    in_file = File(exists=True, mandatory=True, argstr='--in %s',
+                   desc='input PLY pointcloud (vertices + normals)')
+    out_file = File(argstr='--out %s', keep_extension=True,
+                    name_source=['in_file'], name_template='%s_avg',
+                    desc='output PLY triangular mesh')
+
+
+class PoissonReconOutputSpec(TraitedSpec):
+    out_file = File(exists=True, desc='output PLY triangular mesh')
+
+
+class PoissonRecon(CommandLine):
+    """Converts multiple surfaces into a pointcloud with corresponding normals
+    to then apply Poisson reconstruction"""
+    input_spec = PoissonReconInputSpec
+    output_spec = PoissonReconOutputSpec
+    _cmd = 'PoissonRecon'
+
+
+class PLYtoGiftiInputSpec(BaseInterfaceInputSpec):
+    in_file = File(exists=True, mandatory=True, desc='input PLY file')
+    surf_key = traits.Str(mandatory=True, desc='reference GIfTI file')
+
+
+class PLYtoGiftiOutputSpec(TraitedSpec):
+    out_file = File(desc='output GIfTI file')
+
+
+class PLYtoGifti(SimpleInterface):
+    """Converts multiple surfaces into a pointcloud with corresponding normals
+    to then apply Poisson reconstruction"""
+    input_spec = PLYtoGiftiInputSpec
+    output_spec = PLYtoGiftiOutputSpec
+
+    def _run_interface(self, runtime):
+        from pathlib import Path
+        meta = {
+            'GeometricType': 'Anatomical',
+            'VolGeomWidth': '256',
+            'VolGeomHeight': '256',
+            'VolGeomDepth': '256',
+            'VolGeomXsize': '1.0',
+            'VolGeomYsize': '1.0',
+            'VolGeomZsize': '1.0',
+            'VolGeomX_R': '-1.0',
+            'VolGeomX_A': '0.0',
+            'VolGeomX_S': '0.0',
+            'VolGeomY_R': '0.0',
+            'VolGeomY_A': '0.0',
+            'VolGeomY_S': '-1.0',
+            'VolGeomZ_R': '0.0',
+            'VolGeomZ_A': '1.0',
+            'VolGeomZ_S': '0.0',
+            'VolGeomC_R': '0.0',
+            'VolGeomC_A': '0.0',
+            'VolGeomC_S': '0.0',
+        }
+        meta['AnatomicalStructurePrimary'] = 'Cortex%s' % (
+            'Left' if self.inputs.surf_key.startswith('lh') else 'Right')
+        meta['AnatomicalStructureSecondary'] = SECONDARY_ANAT_STRUC[
+            self.inputs.surf_key.split('.')[-1]]
+        meta['Name'] = '%s_average.gii' % self.inputs.surf_key
+
+        out_file = Path(runtime.cwd) / meta['Name']
+        out_file = ply2gii(self.inputs.in_file, meta, out_file=out_file)
+        self._results['out_file'] = str(out_file)
+        return runtime
+
+
+class UnzipJoinedSurfacesInputSpec(BaseInterfaceInputSpec):
+    in_files = traits.List(
+        InputMultiPath(File(exists=True), mandatory=True,
+                       desc='input GIfTI files'))
+
+
+class UnzipJoinedSurfacesOutputSpec(TraitedSpec):
+    out_files = traits.List(
+        OutputMultiPath(File(exists=True),
+                        desc='output pointcloud in PLY format'))
+    surf_keys = traits.List(traits.Str, desc='surface identifier keys')
+
+
+class UnzipJoinedSurfaces(SimpleInterface):
+    """Converts multiple surfaces into a pointcloud with corresponding normals
+    to then apply Poisson reconstruction"""
+    input_spec = UnzipJoinedSurfacesInputSpec
+    output_spec = UnzipJoinedSurfacesOutputSpec
+
+    def _run_interface(self, runtime):
+        from pathlib import Path
+        groups = defaultdict(list)
+        in_files = [it for items in self.inputs.in_files for it in items]
+
+        for f in in_files:
+            bname = Path(f).name
+            groups[bname.split('_')[0]].append(f)
+
+        self._results['out_files'] = [sorted(els) for els in groups.values()]
+        self._results['surf_keys'] = list(groups.keys())
+
+        return runtime
+
+
 def normalize_surfs(in_file, transform_file, newpath=None):
     """ Re-center GIFTI coordinates to fit align to native T1 space
 
@@ -265,3 +481,91 @@ def load_transform(fname):
         return np.genfromtxt(lines)
 
     raise ValueError("Unknown transform type; pass FSL (.mat) or LTA (.lta)")
+
+
+
+def vertex_normals(vertices, faces):
+    """Calculates the normals of a triangular mesh"""
+
+    def normalize_v3(arr):
+        ''' Normalize a numpy array of 3 component vectors shape=(n,3) '''
+        lens = np.sqrt(arr[:, 0]**2 + arr[:, 1]**2 + arr[:, 2]**2)
+        arr /= lens[:, np.newaxis]
+
+    tris = vertices[faces]
+    facenorms = np.cross(tris[::, 1] - tris[::, 0], tris[::, 2] - tris[::, 0])
+    normalize_v3(facenorms)
+
+    norm = np.zeros(vertices.shape, dtype=vertices.dtype)
+    norm[faces[:, 0]] += facenorms
+    norm[faces[:, 1]] += facenorms
+    norm[faces[:, 2]] += facenorms
+    normalize_v3(norm)
+    return norm
+
+
+def pointcloud2ply(vertices, normals, out_file=None):
+    """Converts the file to PLY format"""
+    from pathlib import Path
+    import pandas as pd
+    from pyntcloud import PyntCloud
+    df = pd.DataFrame(np.hstack((vertices, normals)))
+    df.columns = ['x', 'y', 'z', 'nx', 'ny', 'nz']
+    cloud = PyntCloud(df)
+
+    if out_file is None:
+        out_file = Path('pointcloud.ply').resolve()
+
+    cloud.to_file(str(out_file))
+    return out_file
+
+
+def ply2gii(in_file, metadata, out_file=None):
+    """Convert from ply to GIfTI"""
+    from pathlib import Path
+    from numpy import eye
+    from nibabel.gifti import (
+        GiftiMetaData, GiftiCoordSystem, GiftiImage, GiftiDataArray,
+    )
+    from nipype.utils.filemanip import fname_presuffix
+    from pyntcloud import PyntCloud
+
+    in_file = Path(in_file)
+    surf = PyntCloud.from_file(str(in_file))
+
+    # Update centroid metadata
+    metadata.update(
+        zip(('SurfaceCenterX', 'SurfaceCenterY', 'SurfaceCenterZ'),
+            ['%.4f' % c for c in surf.centroid])
+    )
+
+    # Prepare data arrays
+    da = (
+        GiftiDataArray(
+            data=surf.xyz.astype('float32'),
+            datatype='NIFTI_TYPE_FLOAT32',
+            intent='NIFTI_INTENT_POINTSET',
+            meta=GiftiMetaData.from_dict(metadata),
+            coordsys=GiftiCoordSystem(xform=eye(4), xformspace=3)),
+        GiftiDataArray(
+            data=surf.mesh.values,
+            datatype='NIFTI_TYPE_INT32',
+            intent='NIFTI_INTENT_TRIANGLE',
+            coordsys=None))
+    surfgii = GiftiImage(darrays=da)
+
+    if out_file is None:
+        out_file = fname_presuffix(
+            in_file.name, suffix='.gii', use_ext=False, newpath=str(Path.cwd()))
+
+    surfgii.to_filename(str(out_file))
+    return out_file
+
+
+def get_gii_meta(in_file):
+    from nibabel import load
+
+    if isinstance(in_file, list):
+        in_file = in_file[0]
+    gii = load(in_file)
+    return gii.darrays[0].meta.metadata

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+git+https://github.com/daavoo/pyntcloud#egg=pyntcloud-0.0.1
 templateflow>=0.1.0,<0.2.0a0


### PR DESCRIPTION
This PR adds the following new interfaces:
  - [x] `AntsJointFusion`: a new interface to the `antsJointFusion` utility implementing some options missing in nipype. This implementation does not support all the options of the original tool either (meaning, it should be completed before upstreaming to nipype).
  - [x] `GiftiToCSV`: generates CSV files from GIfTIs, thereby permitting moving surfaces with `antsApplyTransformToPoints`.
  - [x] `CSVToGifti`: converts CSV files back to GIfTI, after moving vertices with ``antsApplyTransformToPoints``.
  - [x] `SurfacesToPointCloud`: generates pairs of point clouds and surface normals that are input to Poisson Reconstruction
  - [x] `PoissonRecon`: wraps `PoissonRecon` from https://github.com/mkazhdan/PoissonRecon
  - [x] `PLYtoGifti`: converts surface format from PLY to GIfTI.
  - [x] `UnzipJoinedSurfaces`: arrange surface files and keys for further processing with nipype.