### PR TITLE
FIX: "NONE of the components..." banner was printed even when no AROMA file was present

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,11 +1,14 @@
 0.8.2 (April 4, 2019)
 =====================
 
-New release to go along with the new MRIQC 0.15.0.
+New release to go along with the upcoming MRIQC 0.15.0.
 
-  * FIX: "NONE of the components..." banner was printed even when no AROMA file was present (#330) @oesteban
   * ENH: Update CompCor plotting to allow getting NaNs (#326) @rciric
+  * ENH: Ensure brain mask's conformity (#324) @oesteban
+  * ENH: Add several helper interfaces (#325) @oesteban
+  * FIX: "NONE of the components..." banner was printed even when no AROMA file was present (#330) @oesteban
 
+  
 0.8.1 (March 15, 2019)
 ======================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,11 @@
+0.8.2 (April 4, 2019)
+=====================
+
+New release to go along with the new MRIQC 0.15.0.
+
+  * FIX: "NONE of the components..." banner was printed even when no AROMA file was present (#330) @oesteban
+  * ENH: Update CompCor plotting to allow getting NaNs (#326) @rciric
+
 0.8.1 (March 15, 2019)
 ======================
 

--- a/niworkflows/tests/test_viz.py
+++ b/niworkflows/tests/test_viz.py
@@ -27,12 +27,15 @@ def test_plot_melodic_components():
     import numpy as np
     # save the artifacts
     save_artifacts = os.getenv('SAVE_CIRCLE_ARTIFACTS', False)
+    all_noise = 'melodic_all_noise.svg'
+    no_noise = 'melodic_no_noise.svg'
+    no_classified = 'melodic_no_classified.svg'
+
     if save_artifacts:
         all_noise = os.path.join(save_artifacts, 'melodic_all_noise.svg')
         no_noise = os.path.join(save_artifacts, 'melodic_no_noise.svg')
-    else:
-        all_noise = 'melodic_all_noise.svg'
-        no_noise = 'melodic_no_noise.svg'
+        no_classified = os.path.join(save_artifacts, 'melodic_no_classified.svg')
+
     # melodic directory
     os.makedirs('melodic', exist_ok=True)
     melodic_dir = os.path.join(os.getcwd(), "melodic")
@@ -65,7 +68,7 @@ def test_plot_melodic_components():
     # report_mask
     report_mask = nb.Nifti2Image(np.ones([2, 2, 2]), np.eye(4))
     report_mask.to_filename('report_mask.nii.gz')
-    print(os.getcwd())
+
     # run command with all noise components
     viz.utils.plot_melodic_components(melodic_dir, 'in_file.nii.gz', tr=2.0,
                                       report_mask='report_mask.nii.gz',
@@ -75,3 +78,9 @@ def test_plot_melodic_components():
     viz.utils.plot_melodic_components(melodic_dir, 'in_file.nii.gz', tr=2.0,
                                       report_mask='report_mask.nii.gz',
                                       out_file=no_noise)
+
+    # run command without noise components file
+    viz.utils.plot_melodic_components(melodic_dir, 'in_file.nii.gz', tr=2.0,
+                                      report_mask='report_mask.nii.gz',
+                                      noise_components_file=None,
+                                      out_file=no_classified)

--- a/niworkflows/viz/utils.py
+++ b/niworkflows/viz/utils.py
@@ -685,4 +685,4 @@ def plot_melodic_components(melodic_dir, in_file, tr=None,
                        ' preseveAspectRation="xMidYMid meet" viewBox',
                        image_svg, count=1)
 
-    Path(out_file).write_bytes(image_svg)
+    Path(out_file).write_text(image_svg)


### PR DESCRIPTION
Builds on #292 to improve the way these plots are written. Also adds a `[noise]` tag in the title of those components classified as such.