### PR TITLE
FIX: Do not generate 4D references out of 4D single-band references (SBRefs)

### DIFF
--- a/niworkflows/interfaces/registration.py
+++ b/niworkflows/interfaces/registration.py
@@ -383,7 +383,7 @@ class EstimateReferenceImage(SimpleInterface):
             ref_nii = nb.squeeze_image(nb.load(ref_name))
 
             # If reference is only 1 volume, return it directly
-            if ref_nii.get_data().ndim == 3:
+            if len(ref_nii.shape) == 3:
                 ref_nii.header.extensions.clear()
                 ref_nii.to_filename(out_ref_fname)
                 self._results['ref_image'] = out_ref_fname


### PR DESCRIPTION
``EstimateReferenceImage`` generates 4D references if 4D SBRefs are supplied as input. This patch checks the dimensionality of SBRefs and generates an average if the SBRef is 4D.

Fixes poldracklab/fmriprep#1579.

Intimately related to #253, although I'm not sure the proposed resampling there is absolutely necessary.
It could be detrimental for ``bbregister`` in co-registration.
It is very likely necessary for head-motion correction with either ``mcflirt`` or ``3dVolReg``.