### PR TITLE
FIX: allow pipelining dynamic outputs of ``ReadSidecarJSON``

### DIFF
--- a/niworkflows/conftest.py
+++ b/niworkflows/conftest.py
@@ -18,3 +18,8 @@ def add_np(doctest_namespace):
     doctest_namespace['Path'] = Path
     doctest_namespace['datadir'] = data_dir
     doctest_namespace['bids_collect_data'] = collect_data
+
+
+@pytest.fixture
+def testdata_dir():
+    return data_dir

--- a/niworkflows/interfaces/bids.py
+++ b/niworkflows/interfaces/bids.py
@@ -533,12 +533,10 @@ class ReadSidecarJSON(SimpleInterface):
     def __init__(self, fields=None, undef_fields=False, **inputs):
         super(ReadSidecarJSON, self).__init__(**inputs)
         self._fields = fields or []
+        if isinstance(self._fields, str):
+            self._fields = [self._fields]
+
         self._undef_fields = undef_fields
-
-        if fields:
-            add_traits(self.inputs, fields)
-
-        self.inputs.trait_set(**inputs)
 
     def _outputs(self):
         base = super(ReadSidecarJSON, self)._outputs()

--- a/niworkflows/interfaces/tests/test_bids.py
+++ b/niworkflows/interfaces/tests/test_bids.py
@@ -138,7 +138,7 @@ def test_ReadSidecarJSON_connection(testdata_dir, field):
             (n, o, [(field, 'out_port')]),
         ])
     else:
-        with pytest.raises(Exception) as excinfo:
+        with pytest.raises(Exception, match=r'.*Some connections were not found.*'):
             wf.connect([
                 (n, o, [(field, 'out_port')]),
             ])

--- a/niworkflows/interfaces/tests/test_bids.py
+++ b/niworkflows/interfaces/tests/test_bids.py
@@ -112,3 +112,21 @@ def test_DerivativesDataSink_t1w(tmpdir, space, size, units, xcodes, fixed):
     assert int(nii.header['qform_code']) == XFORM_CODES[space]
     assert int(nii.header['sform_code']) == XFORM_CODES[space]
     assert nii.header.get_xyzt_units() == ('mm', 'unknown')
+
+
+def test_ReadSidecarJSON_connection(testdata_dir):
+    """
+    This test prevents regressions of #333
+    """
+    from nipype.pipeline import engine as pe
+    from nipype.interfaces import utility as niu
+    from niworkflows.interfaces.bids import ReadSidecarJSON
+
+    n = pe.Node(ReadSidecarJSON(fields=['RepetitionTime']), name='node')
+    n.inputs.in_file = str(testdata_dir / 'ds054' / 'sub-100185' / 'fmap' /
+                           'sub-100185_phasediff.nii.gz')
+    o = pe.Node(niu.IdentityInterface(fields=['RepetitionTime']), name='o')
+    wf = pe.Workflow(name='json')
+    wf.connect([
+        (n, o, [('RepetitionTime', 'RepetitionTime')]),
+    ])

--- a/niworkflows/interfaces/tests/test_bids.py
+++ b/niworkflows/interfaces/tests/test_bids.py
@@ -142,5 +142,3 @@ def test_ReadSidecarJSON_connection(testdata_dir, field):
             wf.connect([
                 (n, o, [(field, 'out_port')]),
             ])
-
-        assert 'Some connections were not found' in str(excinfo)


### PR DESCRIPTION
Added two regression tests.

See #333 .