### PR TITLE
ENH: Dictionary manipulation / TSV to dict, merge multiple dicts

### DIFF
--- a/niworkflows/interfaces/utils.py
+++ b/niworkflows/interfaces/utils.py
@@ -718,8 +718,7 @@ class DictMergeInputSpec(BaseInterfaceInputSpec):
 
 
 class DictMergeOutputSpec(TraitedSpec):
-    out_dict = traits.Either(traits.Dict, traits.Instance(OrderedDict),
-                             desc='Merged dictionary')
+    out_dict = traits.Dict(desc='Merged dictionary')
 
 
 class DictMerge(SimpleInterface):


### PR DESCRIPTION
This pull request implements the following:
* `TSV2JSON` can now return a dictionary instead of printing contents to a JSON file. This is used to convert the TSV generated by the nipype `CompCor` interfaces into a dictionary, which can be passed to metadata sinks to produce JSON-formatted metadata. Perhaps this entails renaming the function?
* A new interface, `MergeDict`, merges dictionaries. This is used to combine metadata produced by different confound modelling steps in `fmriprep`. It wouldn't surprise me to learn that there's already an interface somewhere that does this; if so, please let me know so that I can update the code to use that instead. (The node is configured to support ordered output, but I haven't added the code to do that yet because I wasn't sure if there was already a better existing solution.)