### PR TITLE
FIX: BusError in ``DerivativesDataSink``

### DIFF
--- a/niworkflows/interfaces/bids.py
+++ b/niworkflows/interfaces/bids.py
@@ -467,7 +467,8 @@ desc-preproc_bold.json'
 
             is_nii = out_file.endswith('.nii') or out_file.endswith('.nii.gz')
             if self.inputs.check_hdr and is_nii:
-                nii = nb.load(out_file)
+                # Use mmap = False because we may overwrite the file
+                nii = nb.load(out_file, mmap=False)
                 if not isinstance(nii, (nb.Nifti1Image, nb.Nifti2Image)):
                     # .dtseries.nii are CIfTI2, therefore skip check
                     return runtime

--- a/niworkflows/interfaces/tests/test_bids.py
+++ b/niworkflows/interfaces/tests/test_bids.py
@@ -17,35 +17,37 @@ XFORM_CODES = {
 BOLD_PATH = 'ds054/sub-100185/func/sub-100185_task-machinegame_run-01_bold.nii.gz'
 
 
-@pytest.mark.parametrize('space, size, units, xcodes, fixed', [
-    ('T1w', (30, 30, 30, 10), ('mm', 'sec'), (2, 2), [False]),
-    ('T1w', (30, 30, 30, 10), ('mm', 'sec'), (0, 2), [True]),
-    ('T1w', (30, 30, 30, 10), ('mm', 'sec'), (0, 0), [True]),
-    ('T1w', (30, 30, 30, 10), ('mm', None), (2, 2), [True]),
-    ('T1w', (30, 30, 30, 10), (None, None), (0, 2), [True]),
-    ('T1w', (30, 30, 30, 10), (None, 'sec'), (0, 0), [True]),
-    ('MNI152Lin', (30, 30, 30, 10), ('mm', 'sec'), (4, 4), [False]),
-    ('MNI152Lin', (30, 30, 30, 10), ('mm', 'sec'), (0, 2), [True]),
-    ('MNI152Lin', (30, 30, 30, 10), ('mm', 'sec'), (0, 0), [True]),
-    ('MNI152Lin', (30, 30, 30, 10), ('mm', None), (4, 4), [True]),
-    ('MNI152Lin', (30, 30, 30, 10), (None, None), (0, 2), [True]),
-    ('MNI152Lin', (30, 30, 30, 10), (None, 'sec'), (0, 0), [True]),
-    (None, (30, 30, 30, 10), ('mm', 'sec'), (1, 1), [False]),
-    (None, (30, 30, 30, 10), ('mm', 'sec'), (0, 0), [True]),
-    (None, (30, 30, 30, 10), ('mm', 'sec'), (0, 2), [True]),
-    (None, (30, 30, 30, 10), ('mm', None), (1, 1), [True]),
-    (None, (30, 30, 30, 10), (None, None), (0, 2), [True]),
-    (None, (30, 30, 30, 10), (None, 'sec'), (0, 0), [True]),
+@pytest.mark.parametrize('space, size, units, xcodes, zipped, fixed', [
+    ('T1w', (30, 30, 30, 10), ('mm', 'sec'), (2, 2), True, [False]),
+    ('T1w', (30, 30, 30, 10), ('mm', 'sec'), (0, 2), True, [True]),
+    ('T1w', (30, 30, 30, 10), ('mm', 'sec'), (0, 0), True, [True]),
+    ('T1w', (30, 30, 30, 10), ('mm', None), (2, 2), True, [True]),
+    ('T1w', (30, 30, 30, 10), (None, None), (0, 2), True, [True]),
+    ('T1w', (30, 30, 30, 10), (None, 'sec'), (0, 0), True, [True]),
+    ('MNI152Lin', (30, 30, 30, 10), ('mm', 'sec'), (4, 4), True, [False]),
+    ('MNI152Lin', (30, 30, 30, 10), ('mm', 'sec'), (0, 2), True, [True]),
+    ('MNI152Lin', (30, 30, 30, 10), ('mm', 'sec'), (0, 0), True, [True]),
+    ('MNI152Lin', (30, 30, 30, 10), ('mm', None), (4, 4), True, [True]),
+    ('MNI152Lin', (30, 30, 30, 10), (None, None), (0, 2), True, [True]),
+    ('MNI152Lin', (30, 30, 30, 10), (None, 'sec'), (0, 0), True, [True]),
+    (None, (30, 30, 30, 10), ('mm', 'sec'), (1, 1), True, [False]),
+    (None, (30, 30, 30, 10), ('mm', 'sec'), (0, 0), True, [True]),
+    (None, (30, 30, 30, 10), ('mm', 'sec'), (0, 2), True, [True]),
+    (None, (30, 30, 30, 10), ('mm', None), (1, 1), True, [True]),
+    (None, (30, 30, 30, 10), (None, None), (0, 2), True, [True]),
+    (None, (30, 30, 30, 10), (None, 'sec'), (0, 0), True, [True]),
+    (None, (30, 30, 30, 10), (None, 'sec'), (0, 0), False, [True]),
 ])
-def test_DerivativesDataSink_bold(tmpdir, space, size, units, xcodes, fixed):
+def test_DerivativesDataSink_bold(tmpdir, space, size, units, xcodes, zipped, fixed):
     tmpdir.chdir()
+
+    fname = 'source.nii.gz' if zipped else 'source.nii'
 
     hdr = nb.Nifti1Header()
     hdr.set_qform(np.eye(4), code=xcodes[0])
     hdr.set_sform(np.eye(4), code=xcodes[1])
     hdr.set_xyzt_units(*units)
-    nb.Nifti1Image(np.zeros(size), np.eye(4), hdr).to_filename(
-        'source.nii.gz')
+    nb.Nifti1Image(np.zeros(size), np.eye(4), hdr).to_filename(fname)
 
     # BOLD derivative in T1w space
     dds = bintfs.DerivativesDataSink(
@@ -54,7 +56,7 @@ def test_DerivativesDataSink_bold(tmpdir, space, size, units, xcodes, fixed):
         desc='preproc',
         source_file=BOLD_PATH,
         space=space or Undefined,
-        in_file='source.nii.gz'
+        in_file=fname,
     ).run()
 
     nii = nb.load(dds.outputs.out_file)


### PR DESCRIPTION
This may not be necessary if we fix compression, but this test I'm starting with should error and be fixed in either case.

Related: https://github.com/poldracklab/fmriprep/issues/1555