### PR TITLE
FIX: Tolerate missing ANTs at workflow construction

### DIFF
--- a/niworkflows/anat/ants.py
+++ b/niworkflows/anat/ants.py
@@ -231,7 +231,9 @@ def init_brain_extraction_wf(name='brain_extraction_wf',
         name='init_aff',
         n_procs=omp_nthreads)
 
-    if parseversion(Registration().version) > Version('2.2.0'):
+    # Tolerate missing ANTs at construction time
+    _ants_version = Registration().version
+    if _ants_version and parseversion(_ants_version) > Version('2.2.0'):
         init_aff.inputs.search_grid = (40, (0, 40, 40))
 
     # Set up spatial normalization
@@ -244,7 +246,7 @@ def init_brain_extraction_wf(name='brain_extraction_wf',
         mem_gb=mem_gb)
     norm.inputs.float = use_float
     fixed_mask_trait = 'fixed_image_mask'
-    if parseversion(Registration().version) >= Version('2.2.0'):
+    if _ants_version and parseversion(_ants_version) > Version('2.2.0'):
         fixed_mask_trait += 's'
 
     map_brainmask = pe.Node(


### PR DESCRIPTION
We should be able to construct workflows in the absence of an ANTs installation, e.g., when building documentation.