### PR TITLE
ENH: Ensure consistency of headers along brain extraction workflow

### DIFF
--- a/niworkflows/anat/ants.py
+++ b/niworkflows/anat/ants.py
@@ -364,12 +364,11 @@ def init_brain_extraction_wf(name='brain_extraction_wf',
             (get_brainmask, atropos_wf, [
                 ('output_image', 'inputnode.in_mask_dilated')]),
             (atropos_wf, copy_xform, [
-                ('outputnode.out_mask', 'out_mask')]),
-            (atropos_wf, apply_mask, [
-                ('outputnode.out_mask', 'mask_file')]),
-            (atropos_wf, copy_xform, [
+                ('outputnode.out_mask', 'out_mask'),
                 ('outputnode.out_segm', 'out_segm'),
                 ('outputnode.out_tpms', 'out_tpms')]),
+            (copy_xform, apply_mask, [
+                ('out_mask', 'mask_file')]),
             (copy_xform, sel_wm, [('out_tpms', 'inlist')]),
             (sel_wm, inu_n4_final, [('out', 'weight_image')]),
             (copy_xform, outputnode, [

--- a/niworkflows/anat/ants.py
+++ b/niworkflows/anat/ants.py
@@ -363,12 +363,12 @@ def init_brain_extraction_wf(name='brain_extraction_wf',
                 ('output_image', 'inputnode.in_mask')]),
             (get_brainmask, atropos_wf, [
                 ('output_image', 'inputnode.in_mask_dilated')]),
+            (atropos_wf, apply_mask, [
+                ('outputnode.out_mask', 'mask_file')]),
             (atropos_wf, copy_xform, [
                 ('outputnode.out_mask', 'out_mask'),
                 ('outputnode.out_segm', 'out_segm'),
                 ('outputnode.out_tpms', 'out_tpms')]),
-            (copy_xform, apply_mask, [
-                ('out_mask', 'mask_file')]),
             (copy_xform, sel_wm, [('out_tpms', 'inlist')]),
             (sel_wm, inu_n4_final, [('out', 'weight_image')]),
             (copy_xform, outputnode, [

--- a/niworkflows/interfaces/utils.py
+++ b/niworkflows/interfaces/utils.py
@@ -56,7 +56,6 @@ class CopyXForm(SimpleInterface):
         for f in set(self._fields).intersection(list(inputs.keys())):
             setattr(self.inputs, f, inputs[f])
 
-
     def _outputs(self):
         base = super(CopyXForm, self)._outputs()
         if self._fields:
@@ -68,7 +67,6 @@ class CopyXForm(SimpleInterface):
 
             base = add_traits(base, fields)
         return base
-
 
     def _run_interface(self, runtime):
         for f in self._fields:

--- a/niworkflows/interfaces/utils.py
+++ b/niworkflows/interfaces/utils.py
@@ -21,9 +21,11 @@ import scipy.ndimage as nd
 from nipype import logging
 from nipype.utils.filemanip import fname_presuffix
 from nipype.utils.misc import normalize_mc_params
+from nipype.interfaces.io import add_traits
 from nipype.interfaces.base import (
     traits, isdefined, File, InputMultiPath,
-    TraitedSpec, BaseInterfaceInputSpec, SimpleInterface
+    TraitedSpec, BaseInterfaceInputSpec, SimpleInterface,
+    DynamicTraitedSpec
 )
 from .. import __version__
 
@@ -31,13 +33,8 @@ from .. import __version__
 LOG = logging.getLogger('nipype.interface')
 
 
-class CopyXFormInputSpec(BaseInterfaceInputSpec):
-    in_file = File(exists=True, mandatory=True, desc='the file we get the data from')
+class CopyXFormInputSpec(DynamicTraitedSpec, BaseInterfaceInputSpec):
     hdr_file = File(exists=True, mandatory=True, desc='the file we get the header from')
-
-
-class CopyXFormOutputSpec(TraitedSpec):
-    out_file = File(exists=True, desc='written file path')
 
 
 class CopyXForm(SimpleInterface):
@@ -45,17 +42,56 @@ class CopyXForm(SimpleInterface):
     Copy the x-form matrices from `hdr_file` to `out_file`.
     """
     input_spec = CopyXFormInputSpec
-    output_spec = CopyXFormOutputSpec
+    output_spec = DynamicTraitedSpec
+
+    def __init__(self, fields=None, **inputs):
+        self._fields = fields or ['in_file']
+        if isinstance(self._fields, str):
+            self._fields = [self._fields]
+
+        super(CopyXForm, self).__init__(
+            hdr_file=inputs.get('hdr_file', None))
+
+        add_traits(self.inputs, self._fields)
+        for f in set(self._fields).intersection(list(inputs.keys())):
+            setattr(self.inputs, f, inputs[f])
+
+
+    def _outputs(self):
+        base = super(CopyXForm, self)._outputs()
+        if self._fields:
+            fields = self._fields
+            if 'in_file' in fields:
+                idx = fields.index('in_file')
+                fields.pop(idx)
+                fields.insert(idx, 'out_file')
+
+            base = add_traits(base, fields)
+        return base
+
 
     def _run_interface(self, runtime):
-        out_name = fname_presuffix(self.inputs.in_file,
-                                   suffix='_xform',
-                                   newpath=runtime.cwd)
-        # Copy and replace header
-        shutil.copy(self.inputs.in_file, out_name)
-        _copyxform(self.inputs.hdr_file, out_name,
-                   message='CopyXForm (niworkflows v%s)' % __version__)
-        self._results['out_file'] = out_name
+        for f in self._fields:
+            in_files = getattr(self.inputs, f)
+            self._results[f] = []
+            if isinstance(in_files, str):
+                in_files = [in_files]
+            for in_file in in_files:
+                out_name = fname_presuffix(
+                    in_file, suffix='_xform', newpath=runtime.cwd)
+                # Copy and replace header
+                shutil.copy(in_file, out_name)
+                _copyxform(self.inputs.hdr_file, out_name,
+                           message='CopyXForm (niworkflows v%s)' % __version__)
+                self._results[f].append(out_name)
+
+            # Flatten out one-element lists
+            if len(self._results[f]) == 1:
+                self._results[f] = self._results[f][0]
+
+        default = self._results.pop('in_file', None)
+        if default:
+            self._results['out_file'] = default
         return runtime
 
 

--- a/niworkflows/interfaces/utils.py
+++ b/niworkflows/interfaces/utils.py
@@ -49,8 +49,7 @@ class CopyXForm(SimpleInterface):
         if isinstance(self._fields, str):
             self._fields = [self._fields]
 
-        super(CopyXForm, self).__init__(
-            hdr_file=inputs.get('hdr_file', None))
+        super(CopyXForm, self).__init__(**inputs)
 
         add_traits(self.inputs, self._fields)
         for f in set(self._fields).intersection(list(inputs.keys())):


### PR DESCRIPTION
This addresses point 2 of poldracklab/smriprep#82 and will collaborate in solving poldracklab/fmriprep#161.

Changes:

  - [x] The ``CopyXForm`` interfacehas been generalized to accept any number of inputs provided via the ``fields`` argument at instantiation. If no ``fields`` is given, only one file will be manipulated keeping backwards compatibility in naming (``in_file`` -> ``out_file``).
  - [x] Adds a CopyXForm interface to antsBrainExtraction.