### PR TITLE
FIX: Require scikit-learn because nilearn does not

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -205,7 +205,6 @@ jobs:
       - run:
           name: Build and check
           command: |
-            python3 setup.py check -r -s
             python3 setup.py sdist
             python3 -m twine check dist/*
       - run:

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ install_requires =
     jinja2
     matplotlib >= 2.2.0 ; python_version >= "3.6"
     matplotlib >= 2.2.0, < 3.1 ; python_version < "3.6"
+    scikit-learn >= 0.19
     nilearn >= 0.2.6, != 0.5.0, != 0.5.1
     nipype >= 1.1.6
     packaging


### PR DESCRIPTION
It looks like nilearn doesn't correctly specify requirements, so scikit-learn is not installed when nilearn is. However, importing nilearn fails if scikit-learn is missing, so we'll do it ourselves.