### PR TITLE
FIX: Load file with mmap=False when modifying on-disk dtype

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 # data
 include niworkflows/data/*.json
+include niworkflows/data/*.txt
 include niworkflows/data/tests/work/*
 include niworkflows/reports/figures.json
 include niworkflows/reports/fmriprep.yml

--- a/niworkflows/data/itkIdentityTransform.txt
+++ b/niworkflows/data/itkIdentityTransform.txt
@@ -1,0 +1,5 @@
+#Insight Transform File V1.0
+#Transform 0
+Transform: MatrixOffsetTransformBase_double_3_3
+Parameters: 1 0 0 0 1 0 0 0 1 0 0 0
+FixedParameters: 0 0 0

--- a/niworkflows/interfaces/itk.py
+++ b/niworkflows/interfaces/itk.py
@@ -262,7 +262,7 @@ def _applytfms(args):
     runtime = xfm.run().runtime
 
     if copy_dtype:
-        nii = nb.load(out_file)
+        nii = nb.load(out_file, mmap=False)
         in_dtype = nb.load(in_file).get_data_dtype()
 
         # Overwrite only iff dtypes don't match

--- a/niworkflows/interfaces/tests/test_itk.py
+++ b/niworkflows/interfaces/tests/test_itk.py
@@ -1,0 +1,30 @@
+import pytest
+from ..itk import _applytfms
+
+
+@pytest.mark.parametrize('ext', ('.nii', '.nii.gz'))
+@pytest.mark.parametrize('copy_dtype', (True, False))
+@pytest.mark.parametrize('in_dtype', ('i2', 'f4'))
+def test_applytfms(tmpdir, ext, copy_dtype, in_dtype):
+    import numpy as np
+    import nibabel as nb
+    from pkg_resources import resource_filename as pkgr_fn
+    in_file = str(tmpdir / ('src' + ext))
+    nii = nb.Nifti1Image(np.zeros((5, 5, 5), dtype=np.float32), np.eye(4))
+    nii.set_data_dtype(in_dtype)
+    nii.to_filename(in_file)
+
+    in_xform = pkgr_fn('niworkflows', 'data/itkIdentityTransform.txt')
+
+    ifargs = {'copy_dtype': copy_dtype,
+              'reference_image': in_file}
+    args = (in_file, in_xform, ifargs, 0, str(tmpdir))
+    out_file, cmdline = _applytfms(args)
+
+    assert out_file == str(tmpdir / ('src_xform-%05d%s' % (0, ext)))
+
+    out_nii = nb.load(out_file)
+    assert np.allclose(nii.affine, out_nii.affine)
+    assert np.allclose(nii.get_fdata(), out_nii.get_fdata())
+    if copy_dtype:
+        assert nii.get_data_dtype() == out_nii.get_data_dtype()

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,6 +45,7 @@ include_package_data = True
 
 [options.package_data]
 niworkflows =
+    data/*.txt
     data/t1-mni_registration*.json
     data/bold-mni_registration*.json
     reports/figures.json


### PR DESCRIPTION
This causes a BusError reported in [NeuroStars #4641](https://neurostars.org/t/bus-error-fmriprep/4641).