### PR TITLE
TST: Bring EPI brain extraction tests from fMRIPrep

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -205,7 +205,7 @@ jobs:
       - run:
           name: Submit unit test coverage
           command: |
-            python -m codecov --file unittests.xml --root /src/niworkflows \
+            python -m codecov --file unittests.xml --root /tmp/src/niworkflows \
                 --flags unittests -e CIRCLE_JOB
 
       - run:
@@ -223,7 +223,7 @@ jobs:
       - run:
           name: Submit reportlet test coverage
           command: |
-            python -m codecov --file reportlets.xml --root /src/niworkflows \
+            python -m codecov --file reportlets.xml --root /tmp/src/niworkflows \
                 --flags reportlettests -e CIRCLE_JOB
 
       - store_artifacts:
@@ -290,7 +290,7 @@ jobs:
       - run:
           name: Submit masks test coverage
           command: |
-            python -m codecov --file /tmp/masks/coverage.xml --root /src/niworkflows \
+            python -m codecov --file /tmp/masks/coverage.xml --root /tmp/src/niworkflows \
                 --flags masks -e CIRCLE_JOB
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,6 +111,41 @@ jobs:
          paths:
             - /tmp/data
 
+  get_regression_data:
+    machine:
+      # Ubuntu 14.04 with Docker 17.10.0-ce
+      image: circleci/classic:201711-01
+    working_directory: /home/circleci/data
+    steps:
+      - restore_cache:
+          keys:
+            - regression-v1-{{ .Revision }}
+            - regression-v1-
+      - run:
+          name: Get truncated BOLD series
+          command: |
+            mkdir -p /tmp/data
+            if [[ ! -d /tmp/data/fmriprep_bold_truncated ]]; then
+              wget --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 0 -q \
+                -O fmriprep_bold_truncated.tar.gz "https://osf.io/286yr/download"
+              tar xvzf fmriprep_bold_truncated.tar.gz -C /tmp/data/
+            else
+              echo "Truncated BOLD series were cached"
+            fi
+      - run:
+          name: Get pre-computed masks
+          command: |
+            if [[ ! -d /tmp/data/fmriprep_bold_mask ]]; then
+              wget --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 0 -q \
+                -O fmriprep_bold_mask.tar.gz "https://osf.io/s4f7b/download"
+              tar xvzf fmriprep_bold_mask.tar.gz -C /tmp/data/
+            else
+              echo "Pre-computed masks were cached"
+            fi
+      - save_cache:
+         key: regression-v1-{{ .Revision }}-{{ epoch }}
+         paths:
+            - /tmp/data
 
   test_pytest:
     machine:
@@ -125,6 +160,10 @@ jobs:
             - docker-v1-{{ .Branch }}-
             - docker-v1-master-
             - docker-v1-
+      - restore_cache:
+          keys:
+            - regression-v1-{{ .Revision }}
+
       - checkout:
           path: /tmp/src/niworkflows
       - run:
@@ -160,12 +199,13 @@ jobs:
                      --cov niworkflows --cov-report xml:/tmp/unittests.xml \
                      --ignore=/src/niworkflows/niworkflows/tests/ \
                      --ignore=/src/niworkflows/niworkflows/interfaces/ants.py \
+                     --ignore=/src/niworkflows/niworkflows/func/tests/ \
                      /src/niworkflows/niworkflows
 
       - run:
           name: Submit unit test coverage
           command: |
-            python -m codecov --file unittests.xml --root /tmp/src/niworkflows \
+            python -m codecov --file unittests.xml --root /src/niworkflows \
                 --flags unittests -e CIRCLE_JOB
 
       - run:
@@ -183,7 +223,7 @@ jobs:
       - run:
           name: Submit reportlet test coverage
           command: |
-            python -m codecov --file reportlets.xml --root /tmp/src/niworkflows \
+            python -m codecov --file reportlets.xml --root /src/niworkflows \
                 --flags reportlettests -e CIRCLE_JOB
 
       - store_artifacts:
@@ -191,6 +231,80 @@ jobs:
 
       - store_test_results:
           path: /tmp/tests
+
+  test_masks:
+    machine:
+      image: circleci/classic:201711-01
+    working_directory: /tmp/masks
+    steps:
+      - attach_workspace:
+          at: /tmp
+      - restore_cache:
+          keys:
+            - docker-v1-{{ .Branch }}-{{ epoch }}
+            - docker-v1-{{ .Branch }}-
+            - docker-v1-master-
+            - docker-v1-
+      - restore_cache:
+          keys:
+            - regression-v1-{{ .Revision }}
+
+      - checkout:
+          path: /tmp/src/niworkflows
+      - run:
+          name: Load Docker image layer cache
+          no_output_timeout: 30m
+          command: |
+            docker info
+            set +o pipefail
+            if [ -f /tmp/cache/docker.tar.gz ]; then
+              sudo apt update && sudo apt -y install pigz
+              pigz -d --stdout /tmp/cache/docker.tar.gz | docker load
+              docker images
+            fi
+      - run:
+          name: Set PR number
+          command: |
+            echo 'export CIRCLE_PR_NUMBER="${CIRCLE_PR_NUMBER:-${CIRCLE_PULL_REQUEST##*/}}"' >> $BASH_ENV
+            source $BASH_ENV
+            echo $CIRCLE_PR_NUMBER
+      - run:
+          name: Get codecov
+          command: python -m pip install codecov
+
+      - run:
+          name: Run regression tests on EPI masks
+          no_output_timeout: 2h
+          command: |
+            mkdir /tmp/masks/reports && \
+            docker run -ti --rm=false \
+              -v /tmp/data:/tmp/data -v /tmp/masks:/tmp/masks \
+              -e FMRIPREP_REGRESSION_SOURCE=/tmp/data/fmriprep_bold_truncated \
+              -e FMRIPREP_REGRESSION_TARGETS=/tmp/data/fmriprep_bold_mask \
+              -e FMRIPREP_REGRESSION_REPORTS=/tmp/masks/reports \
+              niworkflows:py3 \
+              pytest --junit-xml=/tmp/masks/regression.xml \
+                     --cov niworkflows --cov-report xml:/tmp/masks/coverage.xml \
+                     /src/niworkflows/niworkflows/func/tests/
+
+      - run:
+          name: Submit masks test coverage
+          command: |
+            python -m codecov --file /tmp/masks/coverage.xml --root /src/niworkflows \
+                --flags masks -e CIRCLE_JOB
+
+      - run:
+          name: Package new masks
+          no_output_timeout: 10m
+          working_directory: /tmp/data
+          command: |
+            tar cfz /tmp/masks/fmriprep_bold_mask.tar.gz fmriprep_bold_mask/*/*.nii.gz
+
+      - store_artifacts:
+          path: /tmp/masks
+
+      - store_test_results:
+          path: /tmp/masks
 
   test_package:
     machine:
@@ -257,10 +371,26 @@ workflows:
               only: /.*/
       - get_data:
           filters:
+            branches:
+              ignore:
+                - /masks?\/.*/
             tags:
               only: /.*/
+
+      - get_regression_data:
+          filters:
+            branches:
+              only:
+                - /master/
+                - /masks?\/.*/
+            tags:
+              ignore: /.*/
+
       - test_package:
           filters:
+            branches:
+              ignore:
+                - /masks?\/.*/
             tags:
               only: /.*/
 
@@ -270,9 +400,24 @@ workflows:
             - get_data
           filters:
             branches:
-              ignore: /docs?\/.*/
+              ignore:
+                - /docs?\/.*/
+                - /masks?\/.*/
             tags:
               only: /.*/
+
+      - test_masks:
+          requires:
+            - build
+            - get_regression_data
+          filters:
+            branches:
+              only:
+                - /master/
+                - /masks?\/.*/
+            tags:
+              ignore: /.*/
+
       - deploy:
           requires:
             - test_pytest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -276,7 +276,7 @@ jobs:
           name: Run regression tests on EPI masks
           no_output_timeout: 2h
           command: |
-            mkdir /tmp/masks/reports && \
+            mkdir -p /tmp/masks/reports && \
             docker run -ti --rm=false \
               -v /tmp/data:/tmp/data -v /tmp/masks:/tmp/masks \
               -e FMRIPREP_REGRESSION_SOURCE=/tmp/data/fmriprep_bold_truncated \

--- a/niworkflows/data/epi_atlasbased_brainmask.json
+++ b/niworkflows/data/epi_atlasbased_brainmask.json
@@ -1,0 +1,20 @@
+{
+    "winsorize_upper_quantile": 0.98,
+    "winsorize_lower_quantile": 0.05,
+    "float": true,
+    "metric": ["Mattes"],
+    "metric_weight": [1],
+    "radius_or_number_of_bins": [64],
+    "transforms": ["Affine"],
+    "transform_parameters": [[0.1]],
+    "number_of_iterations": [[200]],
+    "convergence_window_size": [10],
+    "convergence_threshold": [1e-09],
+    "sampling_strategy": ["Random", "Random"],
+    "smoothing_sigmas": [[2]],
+    "sigma_units": ["mm", "mm", "mm"],
+    "shrink_factors": [[2]],
+    "sampling_percentage": [0.2],
+    "use_histogram_matching": [true],
+    "use_estimate_learning_rate_once": [true]
+}

--- a/niworkflows/func/tests/test_util.py
+++ b/niworkflows/func/tests/test_util.py
@@ -1,0 +1,96 @@
+''' Testing module for fmriprep.workflows.bold.util '''
+import pytest
+import os
+from pathlib import Path
+
+import numpy as np
+from nipype.pipeline import engine as pe
+from nipype.utils.filemanip import fname_presuffix, copyfile
+from nilearn.image import load_img
+
+from niworkflows.interfaces.masks import ROIsPlot
+
+from ..util import init_bold_reference_wf
+
+
+def symmetric_overlap(img1, img2):
+    mask1 = load_img(img1).get_data() > 0
+    mask2 = load_img(img2).get_data() > 0
+
+    total1 = np.sum(mask1)
+    total2 = np.sum(mask2)
+    overlap = np.sum(mask1 & mask2)
+    return overlap / np.sqrt(total1 * total2)
+
+
+@pytest.mark.skipif(not os.getenv('FMRIPREP_REGRESSION_SOURCE') or
+                    not os.getenv('FMRIPREP_REGRESSION_TARGETS'),
+                    reason='FMRIPREP_REGRESSION_{SOURCE,TARGETS} env vars not set')
+@pytest.mark.parametrize('input_fname,expected_fname', [
+    (os.path.join(os.getenv('FMRIPREP_REGRESSION_SOURCE', ''),
+                  base_fname),
+     fname_presuffix(base_fname, suffix='_mask', use_ext=True,
+                     newpath=os.path.join(
+                         os.getenv('FMRIPREP_REGRESSION_TARGETS', ''),
+                         os.path.dirname(base_fname))))
+    for base_fname in (
+        'ds000116/sub-12_task-visualoddballwithbuttonresponsetotargetstimuli_run-02_bold.nii.gz',
+        'ds000133/sub-06_ses-post_task-rest_run-01_bold.nii.gz',
+        'ds000140/sub-32_task-heatpainwithregulationandratings_run-02_bold.nii.gz',
+        'ds000157/sub-23_task-passiveimageviewing_bold.nii.gz',
+        'ds000210/sub-06_task-rest_run-01_echo-1_bold.nii.gz',
+        'ds000210/sub-06_task-rest_run-01_echo-2_bold.nii.gz',
+        'ds000210/sub-06_task-rest_run-01_echo-3_bold.nii.gz',
+        'ds000216/sub-03_task-rest_echo-1_bold.nii.gz',
+        'ds000216/sub-03_task-rest_echo-2_bold.nii.gz',
+        'ds000216/sub-03_task-rest_echo-3_bold.nii.gz',
+        'ds000216/sub-03_task-rest_echo-4_bold.nii.gz',
+        'ds000237/sub-03_task-MemorySpan_acq-multiband_run-01_bold.nii.gz',
+        'ds000237/sub-06_task-MemorySpan_acq-multiband_run-01_bold.nii.gz',
+        'ds001240/sub-26_task-localizerimagination_bold.nii.gz',
+        'ds001240/sub-26_task-localizerviewing_bold.nii.gz',
+        'ds001240/sub-26_task-molencoding_run-01_bold.nii.gz',
+        'ds001240/sub-26_task-molencoding_run-02_bold.nii.gz',
+        'ds001240/sub-26_task-molretrieval_run-01_bold.nii.gz',
+        'ds001240/sub-26_task-molretrieval_run-02_bold.nii.gz',
+        'ds001240/sub-26_task-rest_bold.nii.gz',
+        'ds001362/sub-01_task-taskname_run-01_bold.nii.gz',
+    )
+])
+def test_masking(input_fname, expected_fname):
+    bold_reference_wf = init_bold_reference_wf(omp_nthreads=1)
+    bold_reference_wf.inputs.inputnode.bold_file = input_fname
+
+    # Reconstruct base_fname from above
+    dirname, basename = os.path.split(input_fname)
+    dsname = os.path.basename(dirname)
+    reports_dir = Path(os.getenv('FMRIPREP_REGRESSION_REPORTS', ''))
+    newpath = reports_dir / dsname
+    out_fname = fname_presuffix(basename, suffix='_masks.svg', use_ext=False,
+                                newpath=str(newpath))
+    newpath.mkdir(parents=True, exist_ok=True)
+
+    mask_diff_plot = pe.Node(ROIsPlot(colors=['limegreen'], levels=[0.5]),
+                             name='mask_diff_plot')
+    mask_diff_plot.inputs.in_mask = expected_fname
+    mask_diff_plot.inputs.out_report = out_fname
+
+    outputnode = bold_reference_wf.get_node('outputnode')
+    bold_reference_wf.connect([
+        (outputnode, mask_diff_plot, [('ref_image', 'in_file'),
+                                      ('bold_mask', 'in_rois')])
+    ])
+    res = bold_reference_wf.run(plugin='MultiProc')
+
+    combine_masks = [node for node in res.nodes if node.name.endswith('combine_masks')][0]
+    overlap = symmetric_overlap(expected_fname,
+                                combine_masks.result.outputs.out_file)
+
+    mask_dir = reports_dir / 'fmriprep_bold_mask' / dsname
+    mask_dir.mkdir(parents=True, exist_ok=True)
+    copyfile(combine_masks.result.outputs.out_file,
+             fname_presuffix(basename, suffix='_mask',
+                             use_ext=True, newpath=str(mask_dir)),
+             copy=True)
+
+    assert overlap > 0.95, input_fname

--- a/niworkflows/func/util.py
+++ b/niworkflows/func/util.py
@@ -311,7 +311,7 @@ def init_enhance_and_skullstrip_bold_wf(
         # Set up spatial normalization
         norm = pe.Node(Registration(
             from_file=pkgr_fn(
-                'fmriprep.data',
+                'niworkflows.data',
                 'epi_atlasbased_brainmask.json')),
             name='norm',
             n_procs=omp_nthreads)


### PR DESCRIPTION
This PR adds a new build job to the CircleCI workflow to tests regressions on the EPI masking workflows migrated from fMRIPrep (#362).

The infrastructure and tests are replicated from fMRIPrep.

The PR makes CircleCI ignore these tests (branches and tags) except for `master` and branches with name `masks?/*` to minimize churn.

Incidentally, minor fixes to #362 are included.

Closes #371