### PR TITLE
FIX: Revision of previous PR #337 / MELODIC did not converge

### DIFF
--- a/niworkflows/interfaces/segmentation.py
+++ b/niworkflows/interfaces/segmentation.py
@@ -9,7 +9,7 @@ ReportCapableInterfaces for segmentation tools
 from __future__ import absolute_import, division, print_function, unicode_literals
 import os
 
-from nipype.interfaces.base import File, BaseInterface, isdefined
+from nipype.interfaces.base import File, isdefined
 from nipype.interfaces import fsl, freesurfer
 from nipype.interfaces.mixins import reporting
 from . import report_base as nrc

--- a/niworkflows/interfaces/segmentation.py
+++ b/niworkflows/interfaces/segmentation.py
@@ -110,7 +110,6 @@ class MELODICRPT(fsl.MELODIC):
     input_spec = MELODICInputSpecRPT
     output_spec = MELODICOutputSpecRPT
     _out_report = None
-    generate_report = False
 
     def __init__(self, generate_report=False, **kwargs):
         super(MELODICRPT, self).__init__(**kwargs)


### PR DESCRIPTION
This PR tries to resolve a bug introduced in #337. When MELODIC did not
converge, `self._out_report` was rewritten from the input although it
had been manipulated before.

For reliability, the MELODICRPT interface is not a mixin anymore.

<img width="1266" alt="Screen Shot 2019-07-25 at 11 12 27 PM" src="https://user-images.githubusercontent.com/598470/61930185-e6167300-af31-11e9-97f4-a1962f601bce.png">
