### PR TITLE
ENH: Memory optimized header rewriting

### DIFF
--- a/niworkflows/interfaces/bids.py
+++ b/niworkflows/interfaces/bids.py
@@ -12,7 +12,6 @@ from json import dumps
 from pathlib import Path
 from shutil import copytree, rmtree
 
-import numpy as np
 import nibabel as nb
 
 from nipype import logging

--- a/niworkflows/interfaces/bids.py
+++ b/niworkflows/interfaces/bids.py
@@ -25,6 +25,7 @@ from nipype.interfaces.base import (
 from nipype.interfaces.io import add_traits
 from templateflow.api import templates as _get_template_list
 from ..utils.bids import BIDS_NAME, _init_layout
+from ..utils.images import overwrite_header
 from ..utils.misc import splitext as _splitext, _copy_any
 
 
@@ -471,7 +472,7 @@ desc-preproc_bold.json'
                 if not isinstance(nii, (nb.Nifti1Image, nb.Nifti2Image)):
                     # .dtseries.nii are CIfTI2, therefore skip check
                     return runtime
-                hdr = nii.header.copy()
+                hdr = nii.header
                 curr_units = tuple([None if u == 'unknown' else u
                                     for u in hdr.get_xyzt_units()])
                 curr_codes = (int(hdr['qform_code']), int(hdr['sform_code']))
@@ -490,8 +491,7 @@ desc-preproc_bold.json'
                     hdr.set_xyzt_units(*units)
 
                     # Rewrite file with new header
-                    nii.__class__(np.array(nii.dataobj), nii.affine, hdr).to_filename(
-                        out_file)
+                    overwrite_header(nii, out_file)
 
         if len(self._results['out_file']) == 1:
             meta_fields = self.inputs.copyable_trait_names()

--- a/niworkflows/interfaces/bids.py
+++ b/niworkflows/interfaces/bids.py
@@ -467,7 +467,9 @@ desc-preproc_bold.json'
 
             is_nii = out_file.endswith('.nii') or out_file.endswith('.nii.gz')
             if self.inputs.check_hdr and is_nii:
-                nii = nb.load(out_file)
+                # Do not use mmap; if we need to access the data at all, it will be to
+                # rewrite, risking a BusError
+                nii = nb.load(out_file, mmap=False)
                 if not isinstance(nii, (nb.Nifti1Image, nb.Nifti2Image)):
                     # .dtseries.nii are CIfTI2, therefore skip check
                     return runtime

--- a/niworkflows/utils/images.py
+++ b/niworkflows/utils/images.py
@@ -64,9 +64,13 @@ def overwrite_header(img, fname):
     img.update_header()
     header = img.header
     dataobj = img.dataobj
+
+    if getattr(img.dataobj, '_mmap', False):
+        raise ValueError("Image loaded with `mmap=True`. Aborting unsafe operation.")
+
     set_consumables(header, dataobj)
 
-    ondisk = nb.load(fname)
+    ondisk = nb.load(fname, mmap=False)
 
     try:
         assert isinstance(ondisk.header, img.header_class)

--- a/niworkflows/utils/images.py
+++ b/niworkflows/utils/images.py
@@ -48,13 +48,16 @@ def overwrite_header(img, fname):
     that do not change the data or affine, e.g.:
 
     >>> import nibabel as nb
-    >>> img = nb.load(nifti_fname)
+    >>> img = nb.load(nifti_fname, mmap=False)
     >>> img.header.set_qform(*img.header.get_sform(coded=True))
     >>> img.header['descrip'] = b'Modified with some extremely finicky tooling'
     >>> overwrite_header(img, nifti_fname)
 
     This is a destructive operation, and the image object should be considered unusable
     after calling this function.
+
+    This should only be called with an image loaded with ``mmap=False``, or else you
+    risk `BusError`s.
 
     """
     # Synchronize header and set fields that nibabel transfer from header to dataobj
@@ -89,7 +92,7 @@ def update_header_fields(fname, **kwargs):
     # No-op
     if not kwargs:
         return
-    img = nb.load(fname)
+    img = nb.load(fname, mmap=False)
     for field, value in kwargs.items():
         img.header[field] = value
     overwrite_header(img, fname)

--- a/niworkflows/utils/images.py
+++ b/niworkflows/utils/images.py
@@ -1,0 +1,101 @@
+import nibabel as nb
+import numpy as np
+
+
+def unsafe_write_nifti_header_and_data(fname, header, data):
+    """Write header and data without any consistency checks or data munging
+
+    This is almost always a bad idea, and you should not use this function
+    without a battery of tests for your specific use case.
+
+    If you're not using this for NIfTI files specifically, you're playing
+    with Fortran-ordered fire.
+    """
+    # ImageOpener handles zips transparently
+    with nb.openers.ImageOpener(fname, mode='wb') as fobj:
+        header.write_to(fobj)
+        # This function serializes one block at a time to reduce memory usage a bit
+        # It assumes Fortran-ordered data.
+        nb.volumeutils.array_to_file(data, fobj, offset=header.get_data_offset())
+
+
+def set_consumables(header, dataobj):
+    slope, inter = header.get_slope_inter()
+    offset = header.get_data_offset()
+    header.set_slope_inter(dataobj.slope, dataobj.inter)
+    header.set_data_offset(dataobj.offset)
+    return slope, inter, offset
+
+
+def restore_consumables(header, slope, inter, offset):
+    header.set_slope_inter(slope, inter)
+    header.set_data_offset(offset)
+
+
+def overwrite_header(img, fname):
+    """Rewrite file with only changes to the header
+
+    The data block is copied without scaling, avoiding copies in memory.
+    The header is checked against the target file to ensure that no changes
+    to the size, offset or interpretation of the data block will result.
+
+    This function will not respect calls to:
+
+    * img.header.set_slope_inter()
+    * img.header.set_data_shape()
+    * img.header.set_data_offset()
+
+    These will all be determined by img.dataobj, which must be an
+    ArrayProxy.
+
+    If the qform or sform are updated, the
+    ``img.header.get_best_affine()`` method must match ``img.affine``,
+    or your changes may be lost.
+
+    The intended use of this method is for making small header fixups
+    that do not change the data or affine, e.g.:
+
+    >>> import nibabel as nb
+    >>> img = nb.load(fname)
+    >>> img.header.set_qform(*img.header.get_sform(coded=True))
+    >>> img.header['descrip'] = b'Modified with some extremely finicky tooling'
+    >>> overwrite_header(img, fname)
+
+    """
+    # Synchronize header and set fields that nibabel transfer from header to dataobj
+    img.update_header()
+    slope, inter, offset = set_consumables(img.header, img.dataobj)
+    existing_img = nb.load(fname)
+
+    try:
+        assert isinstance(existing_img.header, img.header_class)
+        assert (slope, inter, offset) == set_consumables(existing_img.header, existing_img.dataobj)
+        # Check that the data block should be the same size
+        assert existing_img.get_data_dtype() == img.get_data_dtype()
+        assert existing_img.header.get_data_shape() == img.header.get_data_shape()
+        # At the same offset from the start of the file
+        assert existing_img.header['vox_offset'] == img.header['vox_offset']
+        # With the same scale factors
+        assert np.allclose(existing_img.header['scl_slope'], img.header['scl_slope'],
+                           equal_nan=True)
+        assert np.allclose(existing_img.header['scl_inter'], img.header['scl_inter'],
+                           equal_nan=True)
+    except AssertionError as e:
+        raise ValueError("Cannot write header without compromising data") from e
+    else:
+        dataobj = img.dataobj
+        data = dataobj.get_unscaled() if nb.is_proxy(dataobj) else dataobj
+        unsafe_write_nifti_header_and_data(fname, img.header, data)
+    finally:
+        restore_consumables(img.header, slope, inter, offset)
+
+
+def update_header_fields(fname, **kwargs):
+    """ Adjust header fields """
+    # No-op
+    if not kwargs:
+        return
+    img = nb.load(fname)
+    for field, value in kwargs.items():
+        img.header[field] = value
+    overwrite_header(img, fname)

--- a/niworkflows/utils/images.py
+++ b/niworkflows/utils/images.py
@@ -48,10 +48,10 @@ def overwrite_header(img, fname):
     that do not change the data or affine, e.g.:
 
     >>> import nibabel as nb
-    >>> img = nb.load(fname)
+    >>> img = nb.load(nifti_fname)
     >>> img.header.set_qform(*img.header.get_sform(coded=True))
     >>> img.header['descrip'] = b'Modified with some extremely finicky tooling'
-    >>> overwrite_header(img, fname)
+    >>> overwrite_header(img, nifti_fname)
 
     This is a destructive operation, and the image object should be considered unusable
     after calling this function.

--- a/niworkflows/utils/images.py
+++ b/niworkflows/utils/images.py
@@ -84,7 +84,7 @@ def overwrite_header(img, fname):
         raise ValueError("Cannot write header without compromising data") from e
     else:
         dataobj = img.dataobj
-        data = dataobj.get_unscaled() if nb.is_proxy(dataobj) else dataobj
+        data = np.asarray(dataobj.get_unscaled() if nb.is_proxy(dataobj) else dataobj)
         unsafe_write_nifti_header_and_data(fname, img.header, data)
     finally:
         restore_consumables(img.header, slope, inter, offset)

--- a/niworkflows/utils/tests/test_images.py
+++ b/niworkflows/utils/tests/test_images.py
@@ -1,0 +1,72 @@
+import nibabel as nb
+import numpy as np
+
+import pytest
+from ..images import update_header_fields, overwrite_header
+
+
+def random_image():
+    return nb.Nifti1Image(np.random.random((5, 5, 5, 5)), np.eye(4))
+
+
+@pytest.mark.parametrize("fields", [
+    {},
+    {'intent_code': 0},
+    {'intent_code': 0, 'sform_code': 4},
+    {'sform_code': 3},
+    ])
+@pytest.mark.parametrize("slope, inter", [
+    (None, None),
+    (1., 0.),
+    (2., 2.)
+    ])
+def test_update_header_fields(tmpdir, fields, slope, inter):
+    cwd = tmpdir.chdir()
+    fname = 'test_file.nii'
+    
+    # Generate file
+    init_img = random_image()
+    init_img.header.set_slope_inter(slope, inter)
+    init_img.to_filename(fname)
+
+    # Reference load
+    pre_img = nb.load(fname)
+    pre_data = pre_img.get_fdata()
+
+    update_header_fields(fname, **fields)
+
+    # Post-rewrite load
+    post_img = nb.load(fname)
+
+    # Data should be identical
+    assert np.array_equal(pre_data, post_img.get_fdata())
+
+    cwd.chdir()
+
+
+@pytest.mark.parametrize("fields", [
+    {'scl_slope': 3., 'scl_inter': 3.},
+    {'vox_offset': 20.},
+    {'datatype': 2},
+    ])
+@pytest.mark.parametrize("slope, inter", [
+    (None, None),
+    (2., 2.)
+    ])
+def test_update_header_fields_exceptions(tmpdir, fields, slope, inter):
+    cwd = tmpdir.chdir()
+    fname = 'test_file.nii'
+    
+    # Generate file
+    init_img = random_image()
+    init_img.header.set_slope_inter(slope, inter)
+    init_img.to_filename(fname)
+
+    # Reference load
+    pre_img = nb.load(fname)
+    pre_data = pre_img.get_fdata()
+
+    with pytest.raises(ValueError):
+        update_header_fields(fname, **fields)
+
+    cwd.chdir()

--- a/niworkflows/utils/tests/test_images.py
+++ b/niworkflows/utils/tests/test_images.py
@@ -23,9 +23,8 @@ def random_image():
     (1., 0.),
     (2., 2.)
     ])
-def test_update_header_fields(tmpdir, fields, slope, inter):
-    cwd = tmpdir.chdir()
-    fname = 'test_file.nii'
+def test_update_header_fields(tmp_path, fields, slope, inter):
+    fname = str(tmp_path / 'test_file.nii')
 
     # Generate file
     init_img = random_image()
@@ -44,8 +43,6 @@ def test_update_header_fields(tmpdir, fields, slope, inter):
     # Data should be identical
     assert np.array_equal(pre_data, post_img.get_fdata())
 
-    cwd.chdir()
-
 
 @pytest.mark.parametrize("fields", [
     {'datatype': 2},
@@ -54,9 +51,8 @@ def test_update_header_fields(tmpdir, fields, slope, inter):
     (None, None),
     (2., 2.)
     ])
-def test_update_header_fields_exceptions(tmpdir, fields, slope, inter):
-    cwd = tmpdir.chdir()
-    fname = 'test_file.nii'
+def test_update_header_fields_exceptions(tmp_path, fields, slope, inter):
+    fname = str(tmp_path / 'test_file.nii')
 
     # Generate file
     img = random_image()
@@ -65,5 +61,3 @@ def test_update_header_fields_exceptions(tmpdir, fields, slope, inter):
 
     with pytest.raises(ValueError):
         update_header_fields(fname, **fields)
-
-    cwd.chdir()

--- a/niworkflows/utils/tests/test_images.py
+++ b/niworkflows/utils/tests/test_images.py
@@ -14,6 +14,9 @@ def random_image():
     {'intent_code': 0},
     {'intent_code': 0, 'sform_code': 4},
     {'sform_code': 3},
+    # Changes to these fields have no effect
+    {'scl_slope': 3., 'scl_inter': 3.},
+    {'vox_offset': 20.},
     ])
 @pytest.mark.parametrize("slope, inter", [
     (None, None),
@@ -45,8 +48,6 @@ def test_update_header_fields(tmpdir, fields, slope, inter):
 
 
 @pytest.mark.parametrize("fields", [
-    {'scl_slope': 3., 'scl_inter': 3.},
-    {'vox_offset': 20.},
     {'datatype': 2},
     ])
 @pytest.mark.parametrize("slope, inter", [

--- a/niworkflows/utils/tests/test_images.py
+++ b/niworkflows/utils/tests/test_images.py
@@ -2,7 +2,7 @@ import nibabel as nb
 import numpy as np
 
 import pytest
-from ..images import update_header_fields, overwrite_header
+from ..images import update_header_fields
 
 
 def random_image():
@@ -23,7 +23,7 @@ def random_image():
 def test_update_header_fields(tmpdir, fields, slope, inter):
     cwd = tmpdir.chdir()
     fname = 'test_file.nii'
-    
+
     # Generate file
     init_img = random_image()
     init_img.header.set_slope_inter(slope, inter)
@@ -56,15 +56,11 @@ def test_update_header_fields(tmpdir, fields, slope, inter):
 def test_update_header_fields_exceptions(tmpdir, fields, slope, inter):
     cwd = tmpdir.chdir()
     fname = 'test_file.nii'
-    
-    # Generate file
-    init_img = random_image()
-    init_img.header.set_slope_inter(slope, inter)
-    init_img.to_filename(fname)
 
-    # Reference load
-    pre_img = nb.load(fname)
-    pre_data = pre_img.get_fdata()
+    # Generate file
+    img = random_image()
+    img.header.set_slope_inter(slope, inter)
+    img.to_filename(fname)
 
     with pytest.raises(ValueError):
         update_header_fields(fname, **fields)

--- a/niworkflows/utils/tests/test_images.py
+++ b/niworkflows/utils/tests/test_images.py
@@ -32,7 +32,7 @@ def test_update_header_fields(tmp_path, fields, slope, inter):
     init_img.to_filename(fname)
 
     # Reference load
-    pre_img = nb.load(fname)
+    pre_img = nb.load(fname, mmap=False)
     pre_data = pre_img.get_fdata()
 
     update_header_fields(fname, **fields)

--- a/niworkflows/utils/tests/test_images.py
+++ b/niworkflows/utils/tests/test_images.py
@@ -2,7 +2,7 @@ import nibabel as nb
 import numpy as np
 
 import pytest
-from ..images import update_header_fields
+from ..images import update_header_fields, overwrite_header
 
 
 def random_image():
@@ -61,3 +61,13 @@ def test_update_header_fields_exceptions(tmp_path, fields, slope, inter):
 
     with pytest.raises(ValueError):
         update_header_fields(fname, **fields)
+
+
+def test_overwrite_header_reject_mmap(tmp_path):
+    fname = str(tmp_path / 'test_file.nii')
+
+    random_image().to_filename(fname)
+
+    img = nb.load(fname, mmap=True)
+    with pytest.raises(ValueError):
+        overwrite_header(img, fname)

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@ install_requires =
     matplotlib >= 2.2.0 ; python_version >= "3.6"
     matplotlib >= 2.2.0, < 3.1 ; python_version < "3.6"
     scikit-learn >= 0.19
+    nibabel >= 2.4.1
     nilearn >= 0.2.6, != 0.5.0, != 0.5.1
     nipype >= 1.1.6
     packaging


### PR DESCRIPTION
This provides an alternative to `img.to_filename` that hacks around nibabel's helpfulness to write the raw header and data block without applying or recalculating scale factors. In cases where the scale factors are non-identity, this avoids two full copies of the untouched data object at 64-bit float precision.

This comes with restrictions as to what you can do to the header between read and write, but the memory savings ought to be well worth it.

Inspired by https://github.com/poldracklab/fmriprep/issues/1740 and insomnia.