### PR TITLE
ENH: Add ``copy_header`` inputs to some ANTs interfaces

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -209,40 +209,41 @@ jobs:
           name: Run unit tests
           no_output_timeout: 2h
           command: |
+            mkdir -p $PWD/artifacts $PWD/summaries
             sudo setfacl -d -m group:ubuntu:rwx $PWD
             sudo setfacl -m group:ubuntu:rwx $PWD
-            docker run -it --rm=false \
+            docker run -u $( id -u ) -it --rm=false \
               -e TEST_DATA_HOME=/data -v /tmp/data:/data \
               -v ${PWD}:/tmp niworkflows:py3 \
-              pytest --junit-xml=/tmp/pytest.xml \
-                     --cov niworkflows --cov-report xml:/tmp/unittests.xml \
+              pytest --junit-xml=/tmp/summaries/pytest.xml \
+                     --cov niworkflows --cov-report xml:/tmp/summaries/unittests.xml \
                      --ignore=/src/niworkflows/niworkflows/tests/ \
-                     --ignore=/src/niworkflows/niworkflows/interfaces/ants.py \
                      --ignore=/src/niworkflows/niworkflows/func/tests/ \
                      /src/niworkflows/niworkflows
 
       - run:
           name: Submit unit test coverage
           command: |
-            python -m codecov --file unittests.xml --root /tmp/src/niworkflows \
+            python -m codecov --file summaries/unittests.xml \
+                --root /tmp/src/niworkflows \
                 --flags unittests -e CIRCLE_JOB
 
       - run:
           name: Run reportlet tests
           no_output_timeout: 2h
           command: |
-            docker run -it --rm=false \
-              -e SAVE_CIRCLE_ARTIFACTS="/tmp" \
+            docker run -u $( id -u ) -it --rm=false \
+              -e SAVE_CIRCLE_ARTIFACTS="/tmp/artifacts/" \
               -e TEST_DATA_HOME=/data -v /tmp/data:/data \
               -v /tmp/fslicense/license.txt:/opt/freesurfer/license.txt:ro \
               -v ${PWD}:/tmp niworkflows:py3 \
-              pytest -n auto --junit-xml=/tmp/reportlets.xml \
-                     --cov niworkflows --cov-report xml:/tmp/reportlets.xml \
+              pytest -n auto --junit-xml=/tmp/summaries/reportlets.xml \
+                     --cov niworkflows --cov-report xml:/tmp/summaries/reportlets.xml \
                      /src/niworkflows/niworkflows/tests/
       - run:
           name: Submit reportlet test coverage
           command: |
-            python -m codecov --file reportlets.xml --root /tmp/src/niworkflows \
+            python -m codecov --file summaries/reportlets.xml --root /tmp/src/niworkflows \
                 --flags reportlettests -e CIRCLE_JOB
 
       - run:
@@ -251,10 +252,10 @@ jobs:
             rm -rf /tmp/tests/pytest-of-root
 
       - store_artifacts:
-          path: /tmp/tests
+          path: /tmp/tests/artifacts
 
       - store_test_results:
-          path: /tmp/tests
+          path: /tmp/tests/summaries/
 
   test_masks:
     machine:

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,7 +85,8 @@ script:
     if [ "$CHECK_TYPE" == "style" ]; then
       flake8 niworkflows
     elif [ "$CHECK_TYPE" == "test" ]; then
-      pytest -n 2 -v --cov niworkflows --cov-config .coveragerc --cov-report xml:cov.xml niworkflows
+      pytest -n 2 -v --cov niworkflows --cov-config .coveragerc --cov-report xml:cov.xml \
+             --ignore=niworkflows/interfaces/ants.py niworkflows
     else
       false
     fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -150,7 +150,7 @@ RUN python -c "from matplotlib import font_manager" && \
 WORKDIR /src/
 COPY requirements.txt requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt && \
-    rm -rf ~/.cache/pip
+    rm -rf $HOME/.cache/pip
 
 # Precaching atlases
 RUN python -c "from templateflow import api as tfapi; \
@@ -162,7 +162,12 @@ RUN python -c "from templateflow import api as tfapi; \
 
 COPY . niworkflows/
 RUN pip install --no-cache-dir /src/niworkflows[all] && \
-    rm -rf ~/.cache/pip
+    rm -rf $HOME/.cache/pip
+
+# Cleanup and ensure perms.
+RUN rm -rf $HOME/.npm $HOME/.conda $HOME/.empty && \
+    find $HOME -type d -exec chmod go=u {} + && \
+    find $HOME -type f -exec chmod go=u {} +
 
 # Final settings
 WORKDIR /tmp

--- a/niworkflows/conftest.py
+++ b/niworkflows/conftest.py
@@ -18,6 +18,7 @@ data_dir = Path(test_data_env) / 'BIDS-examples-1-enh-ds054'
 @pytest.fixture(autouse=True)
 def add_np(doctest_namespace):
     doctest_namespace['np'] = np
+    doctest_namespace['nb'] = nb
     doctest_namespace['pd'] = pd
     doctest_namespace['os'] = os
     doctest_namespace['Path'] = Path
@@ -26,12 +27,20 @@ def add_np(doctest_namespace):
     doctest_namespace['test_data'] = pkg_resources.resource_filename('niworkflows', 'tests/data')
 
     tmpdir = tempfile.TemporaryDirectory()
+
     doctest_namespace['tmpdir'] = tmpdir.name
 
     nifti_fname = str(Path(tmpdir.name) / 'test.nii.gz')
-    nb.Nifti1Image(np.random.random((5, 5)).astype('f4'), np.eye(4)).to_filename(nifti_fname)
+    nii = nb.Nifti1Image(np.random.random((5, 5)).astype('f4'), np.eye(4))
+    nii.header.set_qform(np.diag([1, 1, 1, 1]), code=1)
+    nii.header.set_sform(np.diag([-1, 1, 1, 1]), code=1)
+    nii.to_filename(nifti_fname)
     doctest_namespace['nifti_fname'] = nifti_fname
+
+    cwd = os.getcwd()
+    os.chdir(tmpdir.name)
     yield
+    os.chdir(cwd)
     tmpdir.cleanup()
 
 

--- a/niworkflows/interfaces/ants.py
+++ b/niworkflows/interfaces/ants.py
@@ -21,7 +21,7 @@ class _ImageMathInputSpec(ANTSCommandInputSpec):
     op2 = traits.Either(base.File(exists=True), base.Str, position=-1,
                         argstr='%s', desc='second operator')
     copy_header = traits.Bool(
-        True, mandatory=True, usedefault=True,
+        True, usedefault=True,
         desc='copy headers of the original image into the output (corrected) file')
 
 
@@ -35,6 +35,11 @@ class ImageMath(ANTSCommand):
 
     Example
     -------
+    >>> maths = ImageMath(dimension=3, op1=nifti_fname, operation='+', op2='2')
+    >>> result = maths.run()
+    >>> np.all(nb.load(result.outputs.output_image).get_sform() ==
+    ...        nb.load(nifti_fname).get_sform())
+    True
 
     """
 
@@ -164,22 +169,26 @@ class ThresholdImage(ANTSCommand):
 
     Examples
     --------
-    >>> res = ThresholdImage(dimension=3)
-    >>> res.inputs.input_image = nifti_fname
-    >>> res.inputs.output_image = 'output.nii.gz'
-    >>> res.inputs.th_low = 0.5
-    >>> res.inputs.th_high = 1.0
-    >>> res.inputs.inside_value = 1.0
-    >>> res.inputs.outside_value = 0.0
-    >>> res.cmdline  #doctest: +ELLIPSIS
+    >>> thres = ThresholdImage(dimension=3)
+    >>> thres.inputs.input_image = nifti_fname
+    >>> thres.inputs.output_image = 'output.nii.gz'
+    >>> thres.inputs.th_low = 0.5
+    >>> thres.inputs.th_high = 1.0
+    >>> thres.inputs.inside_value = 1.0
+    >>> thres.inputs.outside_value = 0.0
+    >>> thres.cmdline  #doctest: +ELLIPSIS
     'ThresholdImage 3 .../test.nii.gz output.nii.gz 0.500000 1.000000 1.000000 0.000000'
 
-    >>> res = ThresholdImage(dimension=3)
-    >>> res.inputs.input_image = nifti_fname
-    >>> res.inputs.output_image = 'output.nii.gz'
-    >>> res.inputs.mode = 'Kmeans'
-    >>> res.inputs.num_thresholds = 4
-    >>> res.cmdline  #doctest: +ELLIPSIS
+    >>> result = thres.run()
+    >>> os.path.exists(result.outputs.output_image)
+    True
+
+    >>> thres = ThresholdImage(dimension=3)
+    >>> thres.inputs.input_image = nifti_fname
+    >>> thres.inputs.output_image = 'output.nii.gz'
+    >>> thres.inputs.mode = 'Kmeans'
+    >>> thres.inputs.num_thresholds = 4
+    >>> thres.cmdline  #doctest: +ELLIPSIS
     'ThresholdImage 3 .../test.nii.gz output.nii.gz Kmeans 4'
 
     """
@@ -532,7 +541,7 @@ def _copy_header(header_file, in_file, set_dtype=True):
     import nibabel as nb
     in_img = nb.load(header_file)
     out_img = nb.load(in_file, mmap=False)
-    new_img = out_img.__class__(out_img.get_fdata(), in_img.affine,
+    new_img = out_img.__class__(out_img.dataobj, in_img.affine,
                                 in_img.header)
     if set_dtype:
         new_img.set_data_dtype(out_img.get_data_dtype())


### PR DESCRIPTION
This PR adds an input ``copy_header`` to the ``ImageMath`` and ``ThresholdImage`` interfaces because ANTs fails to produce images with appropriate x-form headers.

In particular, these changes are necessary for poldracklab/mriqc#803 to go forward.

In addition to the ``copy_header`` change, some PEP stylistic issues have been addressed.