### PR TITLE
ENH: expand GenerateCifti & MedialNaNs interfaces to support HCP grayordinates / fsLR surfaces

### DIFF
--- a/niworkflows/interfaces/cifti.py
+++ b/niworkflows/interfaces/cifti.py
@@ -135,7 +135,7 @@ class CiftiNameSource(SimpleInterface):
     def _run_interface(self, runtime):
         suffix = 'bold.dtseries'
         if 'hcp' in self.inputs.variant.lower():
-             suffix = 'space-fsLR_bold.dtseries'
+            suffix = 'space-fsLR_bold.dtseries'
         self._results['out_name'] = suffix
         return runtime
 

--- a/niworkflows/interfaces/cifti.py
+++ b/niworkflows/interfaces/cifti.py
@@ -58,9 +58,8 @@ class _GenerateCiftiInputSpec(BaseInterfaceInputSpec):
                                 desc="CIFTI volumetric output space")
     surface_target = traits.Enum("fsLR", "fsaverage5", "fsaverage6", usedefault=True,
                                  desc="CIFTI surface target space")
-    density = traits.Enum(32, 59, 164, usedefault=True,
+    density = traits.Enum('32k', '59k', usedefault=True,
                           help='surface hemisphere vertices')
-    resolution = traits.Enum(2, 1.6, usedefault=True, help='volume resolution (mm)')
     TR = traits.Float(mandatory=True, desc="Repetition time")
     surface_bolds = traits.List(File(exists=True), mandatory=True,
                                 desc="list of surface BOLD GIFTI files"
@@ -138,6 +137,7 @@ class GenerateCifti(SimpleInterface):
         annotation_files = None
         if self.inputs.volume_target == "MNI152NLin2009cAsym":
             tpl_kwargs.update({
+                'resolution': '2',
                 'desc': 'DKT31',
             })
             annotation_files = sorted(
@@ -148,9 +148,11 @@ class GenerateCifti(SimpleInterface):
             )
 
         elif self.inputs.volume_target == 'MNI152NLin6Asym':
+            res = '2' if self.inputs.density == '32k' else '5'
+
             tpl_kwargs.update({
                 'atlas': 'fsLR',
-                'resolution': self.inputs.resolution,
+                'resolution': res,
             })
             annotation_files = [
                 str(f) for f in get_template(

--- a/niworkflows/interfaces/cifti.py
+++ b/niworkflows/interfaces/cifti.py
@@ -135,7 +135,7 @@ class CiftiNameSource(SimpleInterface):
     def _run_interface(self, runtime):
         suffix = 'bold.dtseries'
         if 'hcp' in self.inputs.variant.lower():
-            suffix = 'space-hcp_bold.dtseries'
+             suffix = 'space-fsLR_bold.dtseries'
         self._results['out_name'] = suffix
         return runtime
 

--- a/niworkflows/interfaces/cifti.py
+++ b/niworkflows/interfaces/cifti.py
@@ -160,7 +160,7 @@ class GenerateCifti(SimpleInterface):
             )
 
         elif self.inputs.volume_target == 'MNI152NLin6Asym':
-            res = '2' if self.inputs.density == '32k' else '5'
+            res = '2' if self.inputs.density == '32k' else '6'
 
             tpl_kwargs.update({
                 'atlas': 'HCP',

--- a/niworkflows/interfaces/cifti.py
+++ b/niworkflows/interfaces/cifti.py
@@ -135,6 +135,8 @@ class CiftiNameSource(SimpleInterface):
         suffix = 'bold.dtseries'
         if 'hcp' in self.inputs.variant.lower():
             suffix = 'space-fsLR_bold.dtseries'
+        elif 'fmriprep' in self.inputs.variant.lower():
+            suffix = 'space-fMRIPrep_bold.dtseries'
         self._results['out_name'] = suffix
         return runtime
 
@@ -235,8 +237,7 @@ def _get_cifti_variant(surface, volume, density=None):
 
     """
     if surface in ('fsaverage5', 'fsaverage6'):
-        if not density:
-            density = {'fsaverage5': '10k', 'fsaverage6': '41k'}[surface]
+        density = {'fsaverage5': '10k', 'fsaverage6': '41k'}[surface]
         surface = 'fsaverage'
 
     for variant, targets in CIFTI_VARIANTS.items():
@@ -253,7 +254,7 @@ def _get_cifti_variant(surface, volume, density=None):
         'space': variant,
         'surface': surface,
         'volume': volume,
-        'density': density,
+        'surface_density': density,
     }
     if surface == 'fsLR':
         out_json['grayordinates'] = {'32k': '91k', '59k': '170k'}[density]

--- a/niworkflows/interfaces/cifti.py
+++ b/niworkflows/interfaces/cifti.py
@@ -13,7 +13,7 @@ from nilearn.image import resample_to_img
 from nipype.utils.filemanip import split_filename
 from nipype.interfaces.base import (
     BaseInterfaceInputSpec, TraitedSpec, File, traits,
-    SimpleInterface
+    SimpleInterface, Directory
 )
 from templateflow.api import get as get_template
 
@@ -149,7 +149,7 @@ class GenerateCifti(SimpleInterface):
             )
             if not annotation_files:
                 raise IOError("Freesurfer annotations for %s not found in %s" % (
-                            self.inputs.surface_target, self.inputs.subjects_dir))
+                              self.inputs.surface_target, self.inputs.subjects_dir))
         elif self.inputs.volume_target == 'MNI152NLin6Asym':
             tpl_kwargs.update({
                 'density': self.inputs.density,

--- a/niworkflows/interfaces/cifti.py
+++ b/niworkflows/interfaces/cifti.py
@@ -4,6 +4,7 @@
 import os
 from glob import glob
 import json
+import warnings
 
 import nibabel as nb
 from nibabel import cifti2 as ci
@@ -204,6 +205,7 @@ class GenerateCifti(SimpleInterface):
         bold_img = nb.load(bold_file)
         label_img = nb.load(label_file)
         if label_img.shape != bold_img.shape[:3]:
+            warnings.warn("Resampling bold volume to match label dimensions")
             bold_img = resample_to_img(bold_img, label_img)
 
         bold_data = bold_img.get_fdata(dtype='float32')

--- a/niworkflows/interfaces/cifti.py
+++ b/niworkflows/interfaces/cifti.py
@@ -66,7 +66,7 @@ class _GenerateCiftiInputSpec(BaseInterfaceInputSpec):
     surface_target = traits.Enum("fsLR", "fsaverage5", "fsaverage6", usedefault=True,
                                  desc="CIFTI surface target space")
     density = traits.Enum(None, '32k', '59k', usedefault=True,
-                          help='surface hemisphere vertices')
+                          desc='Surface vertices density. Only required for fsLR surfaces.')
     TR = traits.Float(mandatory=True, desc="Repetition time")
     surface_bolds = traits.List(File(exists=True), mandatory=True,
                                 desc="list of surface BOLD GIFTI files"
@@ -243,7 +243,11 @@ def _get_cifti_variant(surface_target, volume_target, density=None):
             variant = space
             break
     if variant is None:
-        raise NotImplementedError
+        raise NotImplementedError(
+            "No corresponding variant for (surface: {0}, volume: {1})".format(
+                surface_target, volume_target
+            )
+        )
 
     variant_key = os.path.abspath('dtseries_variant.json')
     out_json = {

--- a/niworkflows/interfaces/cifti.py
+++ b/niworkflows/interfaces/cifti.py
@@ -59,7 +59,7 @@ class _GenerateCiftiInputSpec(BaseInterfaceInputSpec):
                                 desc="CIFTI volumetric output space")
     surface_target = traits.Enum("fsLR", "fsaverage5", "fsaverage6", usedefault=True,
                                  desc="CIFTI surface target space")
-    density = traits.Enum('32k', '59k', usedefault=True,
+    density = traits.Enum(None, '32k', '59k', usedefault=True,
                           help='surface hemisphere vertices')
     TR = traits.Float(mandatory=True, desc="Repetition time")
     surface_bolds = traits.List(File(exists=True), mandatory=True,
@@ -251,6 +251,8 @@ class GenerateCifti(SimpleInterface):
                 ts = None
                 for label in labels:
                     ijk = np.nonzero(label_data == label)
+                    if ijk[0].size == 0:  # skip label if nothing matches
+                        continue
                     ts = (bold_data[ijk] if ts is None
                           else np.concatenate((ts, bold_data[ijk])))
                     vox += [[ijk[0][ix], ijk[1][ix], ijk[2][ix]]

--- a/niworkflows/interfaces/cifti.py
+++ b/niworkflows/interfaces/cifti.py
@@ -16,40 +16,46 @@ from nipype.interfaces.base import (
     BaseInterfaceInputSpec, TraitedSpec, File, traits,
     SimpleInterface, Directory
 )
-from templateflow.api import get as get_template
+import templateflow.api as tf
 
-# CITFI structures with corresponding FS labels
-CIFTI_STRUCT_WITH_LABELS = {
+CIFTI_SURFACES = ("fsaverage5", "fsaverage6", "fsLR")
+CIFTI_VOLUMES = ("MNI152NLin2009cAsym", "MNI152NLin6Asym")
+CIFTI_STRUCT_WITH_LABELS = {  # CITFI structures with corresponding labels
     # SURFACES
     'CIFTI_STRUCTURE_CORTEX_LEFT': None,
     'CIFTI_STRUCTURE_CORTEX_RIGHT': None,
 
     # SUBCORTICAL
-    'CIFTI_STRUCTURE_ACCUMBENS_LEFT': [26],
-    'CIFTI_STRUCTURE_ACCUMBENS_RIGHT': [58],
-    'CIFTI_STRUCTURE_AMYGDALA_LEFT': [18],
-    'CIFTI_STRUCTURE_AMYGDALA_RIGHT': [54],
-    'CIFTI_STRUCTURE_BRAIN_STEM': [16],
-    'CIFTI_STRUCTURE_CAUDATE_LEFT': [11],
-    'CIFTI_STRUCTURE_CAUDATE_RIGHT': [50],
-    'CIFTI_STRUCTURE_CEREBELLUM_LEFT': [
+    'CIFTI_STRUCTURE_ACCUMBENS_LEFT': (26,),
+    'CIFTI_STRUCTURE_ACCUMBENS_RIGHT': (58,),
+    'CIFTI_STRUCTURE_AMYGDALA_LEFT': (18,),
+    'CIFTI_STRUCTURE_AMYGDALA_RIGHT': (54,),
+    'CIFTI_STRUCTURE_BRAIN_STEM': (16,),
+    'CIFTI_STRUCTURE_CAUDATE_LEFT': (11,),
+    'CIFTI_STRUCTURE_CAUDATE_RIGHT': (50,),
+    'CIFTI_STRUCTURE_CEREBELLUM_LEFT': (
         6,  # DKT31
         8,  # HCP MNI152
-    ],
-    'CIFTI_STRUCTURE_CEREBELLUM_RIGHT': [
+    ),
+    'CIFTI_STRUCTURE_CEREBELLUM_RIGHT': (
         45,  # DKT31
         47,  # HCP MNI152
-    ],
-    'CIFTI_STRUCTURE_DIENCEPHALON_VENTRAL_LEFT': [28],
-    'CIFTI_STRUCTURE_DIENCEPHALON_VENTRAL_RIGHT': [60],
-    'CIFTI_STRUCTURE_HIPPOCAMPUS_LEFT': [17],
-    'CIFTI_STRUCTURE_HIPPOCAMPUS_RIGHT': [53],
-    'CIFTI_STRUCTURE_PALLIDUM_LEFT': [13],
-    'CIFTI_STRUCTURE_PALLIDUM_RIGHT': [52],
-    'CIFTI_STRUCTURE_PUTAMEN_LEFT': [12],
-    'CIFTI_STRUCTURE_PUTAMEN_RIGHT': [51],
-    'CIFTI_STRUCTURE_THALAMUS_LEFT': [10],
-    'CIFTI_STRUCTURE_THALAMUS_RIGHT': [49],
+    ),
+    'CIFTI_STRUCTURE_DIENCEPHALON_VENTRAL_LEFT': (28,),
+    'CIFTI_STRUCTURE_DIENCEPHALON_VENTRAL_RIGHT': (60,),
+    'CIFTI_STRUCTURE_HIPPOCAMPUS_LEFT': (17,),
+    'CIFTI_STRUCTURE_HIPPOCAMPUS_RIGHT': (53,),
+    'CIFTI_STRUCTURE_PALLIDUM_LEFT': (13,),
+    'CIFTI_STRUCTURE_PALLIDUM_RIGHT': (52,),
+    'CIFTI_STRUCTURE_PUTAMEN_LEFT': (12,),
+    'CIFTI_STRUCTURE_PUTAMEN_RIGHT': (51,),
+    'CIFTI_STRUCTURE_THALAMUS_LEFT': (10,),
+    'CIFTI_STRUCTURE_THALAMUS_RIGHT': (49,),
+}
+CIFTI_VARIANTS = {
+    'HCP grayordinates': ('fsLR', 'MNI152NLin6Asym'),
+    'space1': ('fsaverage5', 'MNI152NLin2009cAsym'),
+    'space2': ('fsaverage6', 'MNI152NLin2009cAsym'),
 }
 
 
@@ -86,236 +92,34 @@ class GenerateCifti(SimpleInterface):
     input_spec = _GenerateCiftiInputSpec
     output_spec = _GenerateCiftiOutputSpec
 
-    _surfaces = ("fsaverage5", "fsaverage6", "fsLR")
-    _volumes = ("MNI152NLin2009cAsym", "MNI152NLin6Asym")
-
     def _run_interface(self, runtime):
-        targets = self._define_variant()
-        annotation_files, label_file = self._fetch_data()
-        self._results["out_file"] = self._create_cifti_image(
+        annotation_files, label_file = _get_cifti_data(
+            self.inputs.surface_target,
+            self.inputs.volume_target,
+            self.inputs.subjects_dir,
+            self.inputs.density
+        )
+        self._results['variant_key'], self._results['variant'] = _get_cifti_variant(
+            self.inputs.surface_target,
+            self.inputs.volume_target,
+            self.inputs.density
+        )
+        self._results["out_file"] = _create_cifti_image(
             self.inputs.bold_file,
             label_file,
             self.inputs.surface_bolds,
-            targets,
+            annotation_files,
             self.inputs.TR,
-            annotation_files=annotation_files)
+            (self.inputs.surface_target, self.inputs.volume_target)
+        )
         return runtime
-
-    def _define_variant(self):
-        """Assign arbitrary label to combination of CIFTI spaces."""
-        space = None
-        variants = {
-            'HCP grayordinates': ['fsLR', 'MNI152NLin6Asym'],
-            'space1': ['fsaverage5', 'MNI152NLin2009cAsym'],
-            'space2': ['fsaverage6', 'MNI152NLin2009cAsym'],
-        }
-        for sp, targets in variants.items():
-            if all(
-                target in targets for target in
-                [self.inputs.surface_target, self.inputs.volume_target]
-            ):
-                space = sp
-        if space is None:
-            raise NotImplementedError
-
-        variant_key = os.path.abspath('dtseries_variant.json')
-        out_json = {
-            'space': space,
-            'surface': variants[space][0],
-            'volume': variants[space][1]
-        }
-        if self.inputs.surface_target == 'fsLR':
-            # 91k == 2mm resolution, 170k == 1.6mm resolution
-            out_json['grayordinates'] = '91k' if self.inputs.density == '32k' else '170k'
-        with open(variant_key, 'w') as fp:
-            json.dump(out_json, fp)
-        self._results['variant_key'] = variant_key
-        self._results['variant'] = space
-        return variants[space]
-
-    def _fetch_data(self):
-        """Converts inputspec to files"""
-        if (
-            self.inputs.surface_target not in self._surfaces or
-            self.inputs.volume_target not in self._volumes
-        ):
-            raise NotImplementedError(
-                "Target space (surface: {0}, volume: {1}) is not supported".format(
-                    self.inputs.surface_target, self.inputs.volume_target
-                )
-            )
-
-        tpl_kwargs = {'suffix': 'dseg'}
-        annotation_files = None
-        if self.inputs.volume_target == "MNI152NLin2009cAsym":
-            tpl_kwargs.update({
-                'resolution': '2',
-                'desc': 'DKT31',
-            })
-            annotation_files = sorted(
-                glob(os.path.join(self.inputs.subjects_dir,
-                                  self.inputs.surface_target,
-                                  'label',
-                                  '*h.aparc.annot'))
-            )
-
-        elif self.inputs.volume_target == 'MNI152NLin6Asym':
-            res = '2' if self.inputs.density == '32k' else '6'
-
-            tpl_kwargs.update({
-                'atlas': 'HCP',
-                'resolution': res,
-            })
-            annotation_files = [
-                str(f) for f in get_template(
-                    'fsLR', density=self.inputs.density, desc='nomedialwall', suffix='dparc'
-                )
-            ]
-
-        if len(annotation_files) != 2:
-            raise IOError("Invalid number of surface annotation files")
-
-        label_file = str(get_template(self.inputs.volume_target, **tpl_kwargs))
-        return annotation_files, label_file
-
-    @staticmethod
-    def _create_cifti_image(bold_file, label_file, bold_surfs,
-                            targets, tr, annotation_files):
-        """
-        Generate CIFTI image in target space.
-
-        Parameters
-            bold_file : str
-                BOLD volumetric timeseries
-            label_file : str
-                Subcortical label file
-            bold_surfs : list
-                BOLD surface timeseries [L,R]
-            targets : list
-                Surface and volumetric output spaces
-            tr : float
-                BOLD repetition time
-            annotation_files : list
-                Surface label files used to remove medial wall
-
-        Returns
-            out :
-                BOLD data saved as CIFTI dtseries
-        """
-        bold_img = nb.load(bold_file)
-        label_img = nb.load(label_file)
-        if label_img.shape != bold_img.shape[:3]:
-            warnings.warn("Resampling bold volume to match label dimensions")
-            bold_img = resample_to_img(bold_img, label_img)
-
-        bold_data = bold_img.get_fdata(dtype='float32')
-        timepoints = bold_img.shape[3]
-        label_data = np.asanyarray(label_img.dataobj).astype('int16')
-
-        # Create brain models
-        idx_offset = 0
-        brainmodels = []
-        bm_ts = np.empty((timepoints, 0))
-
-        for structure, labels in CIFTI_STRUCT_WITH_LABELS.items():
-            if labels is None:  # surface model
-                model_type = "CIFTI_MODEL_TYPE_SURFACE"
-                # use the corresponding annotation
-                hemi = structure.split('_')[-1]
-                # currently only supports L/R cortex
-                surf = nb.load(bold_surfs[hemi == "RIGHT"])
-                surf_verts = len(surf.darrays[0].data)
-                if annotation_files[0].endswith('.annot'):
-                    annot = nb.freesurfer.read_annot(annotation_files[hemi == "RIGHT"])
-                    # remove medial wall
-                    medial = np.nonzero(annot[0] != annot[2].index(b'unknown'))[0]
-                else:
-                    annot = nb.load(annotation_files[hemi == "RIGHT"])
-                    medial = np.nonzero(annot.darrays[0].data)[0]
-                # extract values across volumes
-                ts = np.array([tsarr.data[medial] for tsarr in surf.darrays])
-
-                vert_idx = ci.Cifti2VertexIndices(medial)
-                bm = ci.Cifti2BrainModel(index_offset=idx_offset,
-                                         index_count=len(vert_idx),
-                                         model_type=model_type,
-                                         brain_structure=structure,
-                                         vertex_indices=vert_idx,
-                                         n_surface_vertices=surf_verts)
-                bm_ts = np.column_stack((bm_ts, ts))
-                idx_offset += len(vert_idx)
-                brainmodels.append(bm)
-            else:
-                model_type = "CIFTI_MODEL_TYPE_VOXELS"
-                vox = []
-                ts = None
-                for label in labels:
-                    ijk = np.nonzero(label_data == label)
-                    if ijk[0].size == 0:  # skip label if nothing matches
-                        continue
-                    ts = (bold_data[ijk] if ts is None
-                          else np.concatenate((ts, bold_data[ijk])))
-                    vox += [[ijk[0][ix], ijk[1][ix], ijk[2][ix]]
-                            for ix, row in enumerate(ts)]
-
-                bm_ts = np.column_stack((bm_ts, ts.T))
-
-                vox = ci.Cifti2VoxelIndicesIJK(vox)
-                bm = ci.Cifti2BrainModel(index_offset=idx_offset,
-                                         index_count=len(vox),
-                                         model_type=model_type,
-                                         brain_structure=structure,
-                                         voxel_indices_ijk=vox)
-                idx_offset += len(vox)
-                brainmodels.append(bm)
-
-        # add volume information
-        brainmodels.append(
-            ci.Cifti2Volume(
-                bold_img.shape[:3],
-                ci.Cifti2TransformationMatrixVoxelIndicesIJKtoXYZ(-3, bold_img.affine)
-            )
-        )
-
-        # generate Matrix information
-        series_map = ci.Cifti2MatrixIndicesMap(
-            (0, ),
-            'CIFTI_INDEX_TYPE_SERIES',
-            number_of_series_points=timepoints,
-            series_exponent=0,
-            series_start=0.,
-            series_step=tr,
-            series_unit='SECOND'
-        )
-        geometry_map = ci.Cifti2MatrixIndicesMap(
-            (1, ),
-            'CIFTI_INDEX_TYPE_BRAIN_MODELS',
-            maps=brainmodels
-        )
-        # provide some metadata to CIFTI matrix
-        meta = {
-            "target_surface": targets[0],
-            "target_volume": targets[1],
-        }
-        # generate and save CIFTI image
-        matrix = ci.Cifti2Matrix()
-        matrix.append(series_map)
-        matrix.append(geometry_map)
-        matrix.metadata = ci.Cifti2MetaData(meta)
-        hdr = ci.Cifti2Header(matrix)
-        img = ci.Cifti2Image(bm_ts, hdr)
-        img.nifti_header.set_intent('NIFTI_INTENT_CONNECTIVITY_DENSE_SERIES')
-
-        _, out_base, _ = split_filename(bold_file)
-        out_file = "{}.dtseries.nii".format(out_base)
-        ci.save(img, out_file)
-        return os.path.join(os.getcwd(), out_file)
 
 
 class _CiftiNameSourceInputSpec(BaseInterfaceInputSpec):
-    variant = traits.Str(mandatory=True,
-                         desc=('unique label of spaces used in combination to'
-                               ' generate CIFTI file'))
+    variant = traits.Str(
+        mandatory=True,
+        desc='unique label of spaces used in combination to generate CIFTI file'
+    )
 
 
 class _CiftiNameSourceOutputSpec(TraitedSpec):
@@ -330,7 +134,262 @@ class CiftiNameSource(SimpleInterface):
 
     def _run_interface(self, runtime):
         suffix = 'bold.dtseries'
-        if 'hcp' in self.inputs.variant:
+        if 'hcp' in self.inputs.variant.lower():
             suffix = 'space-hcp_bold.dtseries'
         self._results['out_name'] = suffix
         return runtime
+
+
+def _get_cifti_data(surface_target, volume_target, subjects_dir=None, density=None):
+    """
+    Fetch surface and volumetric label files for CIFTI creation.
+
+    Parameters
+    ----------
+    surface_target : str
+        Target surface space
+    volume_target : str
+        Target volume space
+    subjects_dir : str, optional
+        Path to FreeSurfer subjects directory (required `fsaverage5`/`fsaverage6` surfaces)
+    density : str, optional
+        Surface density (required for `fsLR` surfaces)
+
+    Returns
+    -------
+    annotation_files : list
+        Surface annotation files to allow removal of medial wall
+    label_file : str
+        Volumetric label file of subcortical structures
+
+    Examples
+    --------
+    >>> annots, label = _get_cifti_data('fsLR', 'MNI152NLin6Asym', density='32k')
+    >>> annots  # doctest: +ELLIPSIS
+    ['.../tpl-fsLR_hemi-L_den-32k_desc-nomedialwall_dparc.label.gii', \
+     '.../tpl-fsLR_hemi-R_den-32k_desc-nomedialwall_dparc.label.gii']
+    >>> label  # doctest: +ELLIPSIS
+    '.../tpl-MNI152NLin6Asym_res-02_atlas-HCP_dseg.nii.gz'
+
+    """
+    if surface_target not in CIFTI_SURFACES or volume_target not in CIFTI_VOLUMES:
+        raise NotImplementedError(
+            "Variant (surface: {0}, volume: {1}) is not supported".format(
+                surface_target, volume_target
+            )
+        )
+
+    tpl_kwargs = {'suffix': 'dseg'}
+    if volume_target == "MNI152NLin2009cAsym":
+        tpl_kwargs.update({'resolution': '2', 'desc': 'DKT31'})
+        annotation_files = sorted(glob(os.path.join(
+            subjects_dir,
+            surface_target,
+            'label',
+            '*h.aparc.annot'
+        )))
+    elif volume_target == 'MNI152NLin6Asym':
+        res = {'32k': '2', '59k': '6'}[density]
+        tpl_kwargs.update({
+            'atlas': 'HCP',
+            'resolution': res,
+        })
+        annotation_files = [
+            str(f) for f in tf.get('fsLR', density=density, desc='nomedialwall', suffix='dparc')
+        ]
+
+    if len(annotation_files) != 2:
+        raise IOError("Invalid number of surface annotation files")
+    label_file = str(tf.get(volume_target, **tpl_kwargs))
+    return annotation_files, label_file
+
+
+def _get_cifti_variant(surface_target, volume_target, density=None):
+    """
+    Identify CIFTI variant and return metadata.
+
+    Parameters
+    ----------
+    surface_target : str
+        Target surface space
+    volume_target : str
+        Target volume space
+    density : str, optional
+        Surface density (required for `fsLR` surfaces)
+
+    Returns
+    -------
+    variant_key : str
+        JSON file with variant metadata
+    variant : str
+        Name of CIFTI variant
+
+    Examples
+    --------
+    >>> metafile, variant = _get_cifti_variant('fsaverage5', 'MNI152NLin2009cAsym')
+    >>> metafile  # doctest: +ELLIPSIS
+    '.../dtseries_variant.json'
+    >>> variant
+    'space1'
+
+    >>> _, variant = _get_cifti_variant('fsLR', 'MNI152NLin6Asym', density='59k')
+    >>> variant
+    'HCP grayordinates'
+
+    """
+    variant = None
+    for space, targets in CIFTI_VARIANTS.items():
+        if all(target in targets for target in (surface_target, volume_target)):
+            variant = space
+            break
+    if variant is None:
+        raise NotImplementedError
+
+    variant_key = os.path.abspath('dtseries_variant.json')
+    out_json = {
+        'space': variant,
+        'surfaces': surface_target,
+        'volume': volume_target
+    }
+    if surface_target == 'fsLR':
+        out_json['grayordinates'] = {'32k': '91k', '59k': '170k'}[density]
+
+    with open(variant_key, 'w') as fp:
+        json.dump(out_json, fp)
+    return variant_key, variant
+
+
+def _create_cifti_image(bold_file, label_file, bold_surfs, annotation_files, tr, targets):
+    """
+    Generate CIFTI image in target space.
+
+    Parameters
+    ----------
+    bold_file : str
+        BOLD volumetric timeseries
+    label_file : str
+        Subcortical label file
+    bold_surfs : list
+        BOLD surface timeseries [L,R]
+    annotation_files : list
+        Surface label files used to remove medial wall
+    tr : float
+        BOLD repetition time
+    targets : tuple or list
+        Surface and volumetric output spaces
+
+    Returns
+    -------
+    out :
+        BOLD data saved as CIFTI dtseries
+    """
+    bold_img = nb.load(bold_file)
+    label_img = nb.load(label_file)
+    if label_img.shape != bold_img.shape[:3]:
+        warnings.warn("Resampling bold volume to match label dimensions")
+        bold_img = resample_to_img(bold_img, label_img)
+
+    bold_data = bold_img.get_fdata(dtype='float32')
+    timepoints = bold_img.shape[3]
+    label_data = np.asanyarray(label_img.dataobj).astype('int16')
+
+    # Create brain models
+    idx_offset = 0
+    brainmodels = []
+    bm_ts = np.empty((timepoints, 0))
+
+    for structure, labels in CIFTI_STRUCT_WITH_LABELS.items():
+        if labels is None:  # surface model
+            model_type = "CIFTI_MODEL_TYPE_SURFACE"
+            # use the corresponding annotation
+            hemi = structure.split('_')[-1]
+            # currently only supports L/R cortex
+            surf = nb.load(bold_surfs[hemi == "RIGHT"])
+            surf_verts = len(surf.darrays[0].data)
+            if annotation_files[0].endswith('.annot'):
+                annot = nb.freesurfer.read_annot(annotation_files[hemi == "RIGHT"])
+                # remove medial wall
+                medial = np.nonzero(annot[0] != annot[2].index(b'unknown'))[0]
+            else:
+                annot = nb.load(annotation_files[hemi == "RIGHT"])
+                medial = np.nonzero(annot.darrays[0].data)[0]
+            # extract values across volumes
+            ts = np.array([tsarr.data[medial] for tsarr in surf.darrays])
+
+            vert_idx = ci.Cifti2VertexIndices(medial)
+            bm = ci.Cifti2BrainModel(
+                index_offset=idx_offset,
+                index_count=len(vert_idx),
+                model_type=model_type,
+                brain_structure=structure,
+                vertex_indices=vert_idx,
+                n_surface_vertices=surf_verts
+            )
+            idx_offset += len(vert_idx)
+            bm_ts = np.column_stack((bm_ts, ts))
+        else:
+            model_type = "CIFTI_MODEL_TYPE_VOXELS"
+            vox = []
+            ts = None
+            for label in labels:
+                ijk = np.nonzero(label_data == label)
+                if ijk[0].size == 0:  # skip label if nothing matches
+                    continue
+                ts = (bold_data[ijk] if ts is None
+                      else np.concatenate((ts, bold_data[ijk])))
+                vox += [[ijk[0][ix], ijk[1][ix], ijk[2][ix]]
+                        for ix, row in enumerate(ts)]
+
+            vox = ci.Cifti2VoxelIndicesIJK(vox)
+            bm = ci.Cifti2BrainModel(
+                index_offset=idx_offset,
+                index_count=len(vox),
+                model_type=model_type,
+                brain_structure=structure,
+                voxel_indices_ijk=vox
+            )
+            idx_offset += len(vox)
+            bm_ts = np.column_stack((bm_ts, ts.T))
+        # add each brain structure to list
+        brainmodels.append(bm)
+
+    # add volume information
+    brainmodels.append(
+        ci.Cifti2Volume(
+            bold_img.shape[:3],
+            ci.Cifti2TransformationMatrixVoxelIndicesIJKtoXYZ(-3, bold_img.affine)
+        )
+    )
+
+    # generate Matrix information
+    series_map = ci.Cifti2MatrixIndicesMap(
+        (0, ),
+        'CIFTI_INDEX_TYPE_SERIES',
+        number_of_series_points=timepoints,
+        series_exponent=0,
+        series_start=0.,
+        series_step=tr,
+        series_unit='SECOND'
+    )
+    geometry_map = ci.Cifti2MatrixIndicesMap(
+        (1, ),
+        'CIFTI_INDEX_TYPE_BRAIN_MODELS',
+        maps=brainmodels
+    )
+    # provide some metadata to CIFTI matrix
+    meta = {
+        "target_surface": targets[0],
+        "target_volume": targets[1],
+    }
+    # generate and save CIFTI image
+    matrix = ci.Cifti2Matrix()
+    matrix.append(series_map)
+    matrix.append(geometry_map)
+    matrix.metadata = ci.Cifti2MetaData(meta)
+    hdr = ci.Cifti2Header(matrix)
+    img = ci.Cifti2Image(bm_ts, hdr)
+    img.nifti_header.set_intent('NIFTI_INTENT_CONNECTIVITY_DENSE_SERIES')
+
+    out_file = "{}.dtseries.nii".format(split_filename(bold_file)[1])
+    ci.save(img, out_file)
+    return os.path.join(os.getcwd(), out_file)

--- a/niworkflows/interfaces/cifti.py
+++ b/niworkflows/interfaces/cifti.py
@@ -151,7 +151,7 @@ class GenerateCifti(SimpleInterface):
             res = '2' if self.inputs.density == '32k' else '5'
 
             tpl_kwargs.update({
-                'atlas': 'fsLR',
+                'atlas': 'HCP',
                 'resolution': res,
             })
             annotation_files = [

--- a/niworkflows/interfaces/cifti.py
+++ b/niworkflows/interfaces/cifti.py
@@ -65,9 +65,7 @@ class _GenerateCiftiInputSpec(BaseInterfaceInputSpec):
     surface_bolds = traits.List(File(exists=True), mandatory=True,
                                 desc="list of surface BOLD GIFTI files"
                                      " (length 2 with order [L,R])")
-    surface_annots = traits.List(File(exists=True),
-                                 help="Surface annotation files."
-                                      " Used to exclude medial wall vertices.")
+    subjects_dir = Directory(mandatory=True, desc="FreeSurfer SUBJECTS_DIR")
 
 
 class _GenerateCiftiOutputSpec(TraitedSpec):
@@ -80,7 +78,7 @@ class GenerateCifti(SimpleInterface):
     """
     Generate CIFTI image from BOLD file in target spaces.
 
-    Currently supports ``fsLR`` or ``fsaverage`` for template surfaces and
+    Currently supports ``fsLR``, ``fsaverage5``, or ``fsaverage6`` for template surfaces and
     ``MNI152NLin6Asym`` or ``MNI152NLin2009cAsym`` as template volumes.
 
     """
@@ -104,7 +102,7 @@ class GenerateCifti(SimpleInterface):
         """Assign arbitrary label to combination of CIFTI spaces."""
         space = None
         variants = {
-            'fsLR': ['fsLR', 'MNI152NLin2009cAsym'],
+            'fsLR': ['fsLR', 'MNI152NLin6Asym'],
             'space1': ['fsaverage5', 'MNI152NLin2009cAsym'],
             'space2': ['fsaverage6', 'MNI152NLin2009cAsym'],
         }

--- a/niworkflows/interfaces/freesurfer.py
+++ b/niworkflows/interfaces/freesurfer.py
@@ -296,7 +296,7 @@ class RefineBrainMask(SimpleInterface):
 class _MedialNaNsInputSpec(BaseInterfaceInputSpec):
     in_file = File(exists=True, mandatory=True, desc='input surface file')
     subjects_dir = Directory(mandatory=True, desc='FreeSurfer SUBJECTS_DIR')
-    density = traits.Enum(32, 59, 164, desc="Input file density (fsLR only)")
+    density = traits.Enum('32k', '59k', '164k', desc="Input file density (fsLR only)")
 
 
 class _MedialNaNsOutputSpec(TraitedSpec):
@@ -499,8 +499,8 @@ def medial_wall_to_nan(in_file, subjects_dir, den=None, newpath=None):
         medial = np.delete(np.arange(len(func.darrays[0].data)), cortex)
     elif target_subject == 'fslr' and den is not None:
         hemi = 'L' if fn[:2] == 'lh' else 'R'
-        label_file = tf.get('fsLR', hemi=hemi, desc='nomedialwall', density=den, suffix='dparc')
-        label = nb.load(str(label_file))
+        label_file = str(tf.get('fsLR', hemi=hemi, desc='nomedialwall', density=den, suffix='dparc'))
+        label = nb.load(label_file)
         medial = np.invert(label.darrays[0].data.astype(bool))
     else:
         return in_file

--- a/niworkflows/interfaces/freesurfer.py
+++ b/niworkflows/interfaces/freesurfer.py
@@ -296,7 +296,7 @@ class RefineBrainMask(SimpleInterface):
 class _MedialNaNsInputSpec(BaseInterfaceInputSpec):
     in_file = File(exists=True, mandatory=True, desc='input surface file')
     subjects_dir = Directory(mandatory=True, desc='FreeSurfer SUBJECTS_DIR')
-    density = traits.Enum('32', '59', '164', desc="Input file density (fsLR only)")
+    density = traits.Enum(32, 59, 164, desc="Input file density (fsLR only)")
 
 
 class _MedialNaNsOutputSpec(TraitedSpec):

--- a/niworkflows/interfaces/freesurfer.py
+++ b/niworkflows/interfaces/freesurfer.py
@@ -499,7 +499,9 @@ def medial_wall_to_nan(in_file, subjects_dir, den=None, newpath=None):
         medial = np.delete(np.arange(len(func.darrays[0].data)), cortex)
     elif target_subject == 'fslr' and den is not None:
         hemi = 'L' if fn[:2] == 'lh' else 'R'
-        label_file = str(tf.get('fsLR', hemi=hemi, desc='nomedialwall', density=den, suffix='dparc'))
+        label_file = str(
+            tf.get('fsLR', hemi=hemi, desc='nomedialwall', density=den, suffix='dparc')
+        )
         label = nb.load(label_file)
         medial = np.invert(label.darrays[0].data.astype(bool))
     else:

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ install_requires =
     seaborn
     svgutils
     transforms3d
-    templateflow ~= 0.4.1
+    templateflow ~= 0.4.2rc1
 test_requires =
     pytest >= 4.4
     pytest-xdist >= 1.28


### PR DESCRIPTION
Enhance `GenerateCifti`, `MedialNaNs`, and `CiftiNameSource` interfaces to support HCP grayordinates.

This change depends on templateflow/python-client#31