### PR TITLE
ENH: Reports use the default template from niworkflows, allowing overwrite

### DIFF
--- a/niworkflows/reports/core.py
+++ b/niworkflows/reports/core.py
@@ -278,10 +278,11 @@ class Report(object):
         if self.subject_id is not None:
             self.root = self.root / 'sub-{}'.format(self.subject_id)
 
-        template_path = Path(settings.get('template_path', 'report.tpl'))
-        if not template_path.is_absolute():
-            template_path = config.parent / template_path
-        self.template_path = template_path.resolve()
+        # Default template from niworkflows
+        template_path = Path(pkgrf('niworkflows', 'reports/report.tpl'))
+        if 'template_path' in settings:
+            template_path = config.parent / settings['template_path']
+        self.template_path = template_path.absolute()
         self.index(settings['sections'])
 
     def index(self, config):

--- a/niworkflows/reports/fmriprep.yml
+++ b/niworkflows/reports/fmriprep.yml
@@ -136,4 +136,3 @@ sections:
 - name: About
   reportlets:
   - bids: {datatype: anat, desc: about, suffix: T1w}
-template_path: report.tpl


### PR DESCRIPTION
Addresses the problem spotted by @josephmje in https://github.com/nipreps/dmriprep/pull/28#issuecomment-547540822