### PR TITLE
CI: Drop setup.py install/develop installs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,6 @@ env:
   matrix:
     - CHECK_TYPE="style"
     - CHECK_TYPE="test"
-    - INSTALL_TYPE="install"
-    - INSTALL_TYPE="develop"
     - INSTALL_TYPE="sdist"
     - INSTALL_TYPE="wheel"
     - INSTALL_DEPENDS="pip==18.1 setuptools==30.2.1"
@@ -59,14 +57,7 @@ before_install:
     fi
 
 install:
-  - |
-    if [ "$INSTALL_TYPE" == "install" ]; then
-        python setup.py install
-    elif [ "$INSTALL_TYPE" == "develop" ]; then
-        python setup.py develop
-    else
-        python -m pip install $PACKAGE
-    fi
+  - python -m pip install $PACKAGE
   - |
     INTENDED_VERSION="$(python -c 'import versioneer; print(versioneer.get_version())')"
     pushd /tmp


### PR DESCRIPTION
Scikit-image is an obnoxious dependency that breaks using `python setup.py {install,develop}` which is causing Travis failures.

Nobody installs this way anymore, so it's not worth supporting this use case. I'm just switching to `pip`.

Objections?