### PR TITLE
FIX: Ensure data type of masked image matches T1.mgz

### DIFF
--- a/niworkflows/interfaces/freesurfer.py
+++ b/niworkflows/interfaces/freesurfer.py
@@ -376,7 +376,7 @@ def inject_skullstripped(subjects_dir, subject_id, skullstripped):
         mask = nb.load(skullstripped)
         bmask = new_img_like(mask, np.asanyarray(mask.dataobj) > 0)
         resampled_mask = resample_to_img(bmask, img, 'nearest')
-        masked_image = new_img_like(img, img.get_fdata() * resampled_mask.dataobj)
+        masked_image = new_img_like(img, np.asanyarray(img.dataobj) * resampled_mask.dataobj)
         masked_image.to_filename(bm_auto)
 
     if not op.exists(bm):

--- a/niworkflows/interfaces/tests/test_freesurfer.py
+++ b/niworkflows/interfaces/tests/test_freesurfer.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+import numpy as np
+import nibabel as nb
+from ..freesurfer import FSInjectBrainExtracted
+
+
+def test_inject_skullstrip(tmp_path):
+    t1_mgz = tmp_path / "sub-01" / "mri" / "T1.mgz"
+    t1_mgz.parent.mkdir(parents=True)
+    # T1.mgz images are uint8
+    nb.MGHImage(np.ones((5, 5, 5), dtype=np.uint8), np.eye(4)).to_filename(str(t1_mgz))
+
+    mask_nii = tmp_path / "mask.nii.gz"
+    # Masks may be in a different space (and need resampling), but should be boolean,
+    # or uint8 in NIfTI
+    nb.Nifti1Image(np.ones((6, 6, 6), dtype=np.uint8), np.eye(4)).to_filename(
+        str(mask_nii)
+    )
+
+    FSInjectBrainExtracted(
+        subjects_dir=str(tmp_path), subject_id="sub-01", in_brain=str(mask_nii)
+    ).run()
+
+    assert Path.exists(tmp_path / "sub-01" / "mri" / "brainmask.auto.mgz")
+    assert Path.exists(tmp_path / "sub-01" / "mri" / "brainmask.mgz")
+
+    # Run a second time to hit "already exists" condition
+    FSInjectBrainExtracted(
+        subjects_dir=str(tmp_path), subject_id="sub-01", in_brain=str(mask_nii)
+    ).run()


### PR DESCRIPTION
Fix for https://github.com/poldracklab/fmriprep/issues/1890.

FreeSurfer anatomical images are scaled to `uint8`s, so coercing to float was problematic.