### PR TITLE
MNT: Specify junit_family to suppress pytest DeprecationWarning

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -114,6 +114,7 @@ env =
     PYTHONHASHSEED=0
 filterwarnings =
     ignore::DeprecationWarning
+junit_family=xunit2
 
 [coverage:run]
 branch = True


### PR DESCRIPTION
https://docs.pytest.org/en/latest/deprecations.html#junit-family-default-value-change-to-xunit2