### PR TITLE
ENH: CIFTI / fsLR density

### DIFF
--- a/niworkflows/interfaces/cifti.py
+++ b/niworkflows/interfaces/cifti.py
@@ -140,7 +140,6 @@ class CiftiNameSource(SimpleInterface):
 
     Examples
     --------
-
     >>> namer = CiftiNameSource()
     >>> namer.inputs.variant = 'HCP grayordinates'
     >>> res = namer.run()

--- a/niworkflows/interfaces/cifti.py
+++ b/niworkflows/interfaces/cifti.py
@@ -135,7 +135,24 @@ class _CiftiNameSourceOutputSpec(TraitedSpec):
 
 
 class CiftiNameSource(SimpleInterface):
-    """Construct new filename based on unique label of spaces used to generate a CIFTI file."""
+    """
+    Construct new filename based on unique label of spaces used to generate a CIFTI file.
+
+    Examples
+    --------
+
+    >>> namer = CiftiNameSource()
+    >>> namer.inputs.variant = 'HCP grayordinates'
+    >>> res = namer.run()
+    >>> res.outputs.out_name
+    'space-fsLR_bold.dtseries'
+
+    >>> namer.inputs.density = '32k'
+    >>> res = namer.run()
+    >>> res.outputs.out_name
+    'space-fsLR_den-32k_bold.dtseries'
+
+    """
 
     input_spec = _CiftiNameSourceInputSpec
     output_spec = _CiftiNameSourceOutputSpec

--- a/niworkflows/interfaces/cifti.py
+++ b/niworkflows/interfaces/cifti.py
@@ -236,15 +236,17 @@ def _get_cifti_variant(surface, volume, density=None):
 
     Examples
     --------
-    >>> metafile, variant = _get_cifti_variant('fsaverage5', 'MNI152NLin2009cAsym')
+    >>> metafile, variant, _ = _get_cifti_variant('fsaverage5', 'MNI152NLin2009cAsym')
     >>> metafile  # doctest: +ELLIPSIS
     '.../dtseries_variant.json'
     >>> variant
     'fMRIPrep grayordinates'
 
-    >>> _, variant = _get_cifti_variant('fsLR', 'MNI152NLin6Asym', density='59k')
+    >>> _, variant, grayords = _get_cifti_variant('fsLR', 'MNI152NLin6Asym', density='59k')
     >>> variant
     'HCP grayordinates'
+    >>> grayords
+    '170k'
 
     """
     if surface in ('fsaverage5', 'fsaverage6'):

--- a/niworkflows/interfaces/surf.py
+++ b/niworkflows/interfaces/surf.py
@@ -134,12 +134,12 @@ class GiftiNameSource(SimpleInterface):
 
     >>> namer = GiftiNameSource()
     >>> namer.inputs.pattern = r'(?P<LR>[lr])h.(?P<space>\w+).gii'
-    >>> namer.inputs.template = r'space-{space}.{den}.{LR}.func'
+    >>> namer.inputs.template = r'space-{space}_density-{density}_hemi-{LR}.func'
     >>> namer.inputs.in_file = 'rh.fsaverage.gii'
-    >>> namer.inputs.template_kwargs = {'den': '10k'}
+    >>> namer.inputs.template_kwargs = {'density': '10k'}
     >>> res = namer.run()
     >>> res.outputs.out_name
-    'space-fsaverage.10k.R.func'
+    'space-fsaverage_density-10k_hemi-R.func'
 
     .. testcleanup::
 


### PR DESCRIPTION
- Adds new `density` output to `GenerateCifti` interface to allow tracking CIFTI file density (grayordinates)
- Adds `density` to `NameCifti` to differentiate low/high res data.
- Adds `template_kwargs` to `GiftiNameSource` to allow more flexible formatting