### PR TITLE
ENH: Separate ``Space`` and ``SpatialReferences``

### DIFF
--- a/niworkflows/conftest.py
+++ b/niworkflows/conftest.py
@@ -1,5 +1,6 @@
 """py.test configuration"""
 import os
+from sys import version_info
 from pathlib import Path
 import numpy as np
 import nibabel as nb
@@ -17,10 +18,12 @@ data_dir = Path(test_data_env) / 'BIDS-examples-1-enh-ds054'
 
 @pytest.fixture(autouse=True)
 def add_np(doctest_namespace):
+    doctest_namespace['PY_VERSION'] = version_info
     doctest_namespace['np'] = np
     doctest_namespace['nb'] = nb
     doctest_namespace['pd'] = pd
     doctest_namespace['os'] = os
+    doctest_namespace['pytest'] = pytest
     doctest_namespace['Path'] = Path
     doctest_namespace['datadir'] = data_dir
     doctest_namespace['bids_collect_data'] = collect_data

--- a/niworkflows/utils/spaces.py
+++ b/niworkflows/utils/spaces.py
@@ -490,28 +490,24 @@ def _expand_entities(entities):
 
     Ported from PyBIDS
 
+
+    .. testsetup::
+
+        >>> if PY_VERSION < (3, 6):
+        ...     pytest.skip("This doctest does not work on python <3.6")
+
     Examples
     --------
     >>> entities = {'subject': ['01', '02'], 'session': ['1', '2'], 'task': ['rest', 'finger']}
-    >>> out = _expand_entities(entities)
-    >>> len(out)
-    8
-    >>> {'subject': '01', 'session': '1', 'task': 'rest'} in out
-    True
-    >>> {'subject': '02', 'session': '1', 'task': 'rest'} in out
-    True
-    >>> {'subject': '01', 'session': '2', 'task': 'rest'} in out
-    True
-    >>> {'subject': '02', 'session': '2', 'task': 'rest'} in out
-    True
-    >>> {'subject': '01', 'session': '1', 'task': 'finger'} in out
-    True
-    >>> {'subject': '02', 'session': '1', 'task': 'finger'} in out
-    True
-    >>> {'subject': '01', 'session': '2', 'task': 'finger'} in out
-    True
-    >>> {'subject': '02', 'session': '2', 'task': 'finger'} in out
-    True
+    >>> _expand_entities(entities)
+    [{'subject': '01', 'session': '1', 'task': 'rest'},
+     {'subject': '02', 'session': '1', 'task': 'rest'},
+     {'subject': '01', 'session': '2', 'task': 'rest'},
+     {'subject': '02', 'session': '2', 'task': 'rest'},
+     {'subject': '01', 'session': '1', 'task': 'finger'},
+     {'subject': '02', 'session': '1', 'task': 'finger'},
+     {'subject': '01', 'session': '2', 'task': 'finger'},
+     {'subject': '02', 'session': '2', 'task': 'finger'}]
 
     """
     keys = list(entities.keys())

--- a/niworkflows/utils/spaces.py
+++ b/niworkflows/utils/spaces.py
@@ -264,6 +264,9 @@ class Space:
         [Space(name='MNIPediatricAsym', spec={'cohort': '1'}),
          Space(name='MNIPediatricAsym', spec={'cohort': '2'})]
 
+        >>> Space.from_string("fsaverage:den-10k:den-164k")
+        [Space(name='fsaverage', spec={'den': '10k'}),
+         Space(name='fsaverage', spec={'den': '164k'})]
 
         >>> Space.from_string("MNIPediatricAsym:cohort-5:cohort-6:res-2")
         [Space(name='MNIPediatricAsym', spec={'cohort': '5', 'res': '2'}),
@@ -414,9 +417,11 @@ class SpatialReferences:
                 return True
         return False
 
-    def __repr__(self):
+    def __str__(self):
         """Representation of this object."""
-        return 'Imaging spaces:%s' % '\n  - '.join([] + [str(s) for s in self.spaces])
+        if not self._spaces:
+            return 'Spatial References: <none>.'
+        return 'Spatial References:%s' % '\n  - '.join([] + [str(s) for s in self.spaces])
 
     @property
     def spaces(self):

--- a/niworkflows/utils/spaces.py
+++ b/niworkflows/utils/spaces.py
@@ -136,40 +136,6 @@ class Space:
     >>> sp1 == sp2
     True
 
-    >>> Space.from_string("MNI152NLin2009cAsym")
-    [Space(name='MNI152NLin2009cAsym', spec={})]
-
-    >>> # Bad name
-    >>> Space.from_string("shouldraise")
-    Traceback (most recent call last):
-      ...
-    ValueError: space identifier "shouldraise" is invalid.
-    ...
-
-    >>> # Missing cohort
-    >>> Space.from_string("MNIPediatricAsym")
-    Traceback (most recent call last):
-      ...
-    ValueError: standard space "MNIPediatricAsym" is not fully defined.
-    ...
-
-    >>> Space.from_string("MNIPediatricAsym:cohort-1")
-    [Space(name='MNIPediatricAsym', spec={'cohort': '1'})]
-
-    >>> Space.from_string("MNIPediatricAsym:cohort-1:cohort-2")
-    [Space(name='MNIPediatricAsym', spec={'cohort': '1'}),
-     Space(name='MNIPediatricAsym', spec={'cohort': '2'})]
-
-    >>> Space.from_string("MNIPediatricAsym:cohort-5:cohort-6:res-2")
-    [Space(name='MNIPediatricAsym', spec={'cohort': '5', 'res': '2'}),
-     Space(name='MNIPediatricAsym', spec={'cohort': '6', 'res': '2'})]
-
-    >>> Space.from_string("MNIPediatricAsym:cohort-5:cohort-6:res-2:res-iso1.6mm")
-    [Space(name='MNIPediatricAsym', spec={'cohort': '5', 'res': '2'}),
-     Space(name='MNIPediatricAsym', spec={'cohort': '5', 'res': 'iso1.6mm'}),
-     Space(name='MNIPediatricAsym', spec={'cohort': '6', 'res': '2'}),
-     Space(name='MNIPediatricAsym', spec={'cohort': '6', 'res': 'iso1.6mm'})]
-
     """
 
     _standard_spaces = tuple(_tfapi.templates())
@@ -252,7 +218,58 @@ class Space:
 
     @classmethod
     def from_string(cls, value):
-        """Create a new Space from string."""
+        """
+        Parse a string to generate the corresponding list of Spaces.
+
+        Parameters
+        ----------
+        value: :obj:`str`
+            A string containing a space specification following *fMRIPrep*'s
+            language for ``--output-spaces``
+            (e.g., ``MNIPediatricAsym:cohort-1:cohort-2:res-1:res-2``).
+
+        Returns
+        -------
+        spaces : :obj:`list` of :obj:`Space`
+            A list of corresponding spaces given the input string.
+
+        Examples
+        --------
+        >>> Space.from_string("MNI152NLin2009cAsym")
+        [Space(name='MNI152NLin2009cAsym', spec={})]
+
+        >>> # Bad name
+        >>> Space.from_string("shouldraise")
+        Traceback (most recent call last):
+          ...
+        ValueError: space identifier "shouldraise" is invalid.
+        ...
+
+        >>> # Missing cohort
+        >>> Space.from_string("MNIPediatricAsym")
+        Traceback (most recent call last):
+          ...
+        ValueError: standard space "MNIPediatricAsym" is not fully defined.
+        ...
+
+        >>> Space.from_string("MNIPediatricAsym:cohort-1")
+        [Space(name='MNIPediatricAsym', spec={'cohort': '1'})]
+
+        >>> Space.from_string("MNIPediatricAsym:cohort-1:cohort-2")
+        [Space(name='MNIPediatricAsym', spec={'cohort': '1'}),
+         Space(name='MNIPediatricAsym', spec={'cohort': '2'})]
+
+        >>> Space.from_string("MNIPediatricAsym:cohort-5:cohort-6:res-2")
+        [Space(name='MNIPediatricAsym', spec={'cohort': '5', 'res': '2'}),
+         Space(name='MNIPediatricAsym', spec={'cohort': '6', 'res': '2'})]
+
+        >>> Space.from_string("MNIPediatricAsym:cohort-5:cohort-6:res-2:res-iso1.6mm")
+        [Space(name='MNIPediatricAsym', spec={'cohort': '5', 'res': '2'}),
+         Space(name='MNIPediatricAsym', spec={'cohort': '5', 'res': 'iso1.6mm'}),
+         Space(name='MNIPediatricAsym', spec={'cohort': '6', 'res': '2'}),
+         Space(name='MNIPediatricAsym', spec={'cohort': '6', 'res': 'iso1.6mm'})]
+
+        """
         _args = value.split(':')
         spec = defaultdict(list, {})
         for modifier in _args[1:]:
@@ -370,9 +387,9 @@ class SpatialReferences:
         if spaces is not None:
             if isinstance(spaces, str):
                 spaces = [spaces]
-            self.__add__(spaces)
+            self.__iadd__(spaces)
 
-    def __add__(self, b):
+    def __iadd__(self, b):
         """Append a list of transforms to the internal list."""
         if not isinstance(b, (list, tuple)):
             raise TypeError('Must be a list.')

--- a/niworkflows/utils/spaces.py
+++ b/niworkflows/utils/spaces.py
@@ -416,7 +416,7 @@ class SpatialReferences:
 
     def __repr__(self):
         """Representation of this object."""
-        return 'Imaging spaces: %s' % ', '.join([s.fullname for s in self.spaces])
+        return 'Imaging spaces:%s' % '\n  - '.join([] + [str(s) for s in self.spaces])
 
     @property
     def spaces(self):
@@ -501,6 +501,7 @@ def _expand_entities(entities):
 
 
     .. testsetup::
+
         >>> if PY_VERSION < (3, 6):
         ...     pytest.skip("This doctest does not work on python <3.6")
 

--- a/niworkflows/utils/spaces.py
+++ b/niworkflows/utils/spaces.py
@@ -84,7 +84,7 @@ class Space:
     ValueError: space identifier "shouldraise" is invalid.
     ...
 
-    # Check standard property
+    >>> # Check standard property
     >>> Space('func').standard
     False
     >>> Space('MNI152Lin').standard

--- a/niworkflows/utils/spaces.py
+++ b/niworkflows/utils/spaces.py
@@ -418,10 +418,27 @@ class SpatialReferences:
         return False
 
     def __str__(self):
-        """Representation of this object."""
-        if not self._spaces:
-            return 'Spatial References: <none>.'
-        return 'Spatial References:%s' % '\n  - '.join([] + [str(s) for s in self.spaces])
+        """
+        Representation of this object.
+
+        Examples
+        --------
+        >>> print(SpatialReferences())
+        Spatial References: <none>.
+
+        >>> print(SpatialReferences(['MNI152NLin2009cAsym']))
+        Spatial References:
+            - Space(name='MNI152NLin2009cAsym', spec={})
+
+        >>> print(SpatialReferences(['MNI152NLin2009cAsym', 'fsaverage5']))
+        Spatial References:
+            - Space(name='MNI152NLin2009cAsym', spec={})
+            - Space(name='fsaverage', spec={'den': '10k'})
+
+        """
+        spaces = '\n    - '.join([''] + [str(s) for s in self.spaces]) \
+            if self.spaces else ' <none>.'
+        return 'Spatial References:%s' % spaces
 
     @property
     def spaces(self):
@@ -482,11 +499,14 @@ class SpatialReferences:
                 if s.name in ("fsaverage", "fsnative")]
 
 
-class StoreSpacesAction(argparse.Action):
+class OutputSpacesAction(argparse.Action):
+    """Parse spatial references."""
+
     def __call__(self, parser, namespace, values, option_string=None):
-        spaces = getattr(namespace, self.dest) or []
+        """Execute parser."""
+        spaces = getattr(namespace, self.dest) or SpatialReferences()
         for val in values:
-            spaces.extend(Space.from_string(val))
+            spaces += Space.from_string(val)
         setattr(namespace, self.dest, spaces)
 
 

--- a/niworkflows/utils/spaces.py
+++ b/niworkflows/utils/spaces.py
@@ -1,6 +1,5 @@
 """Utilities for tracking and filtering spaces."""
 import attr
-import typing
 from collections import defaultdict
 from itertools import product
 from templateflow import api as _tfapi
@@ -161,15 +160,15 @@ class Space:
 
     _standard_spaces = tuple(_tfapi.templates())
 
-    name: str = attr.ib(default=None)
+    name = attr.ib(default=None, type=str)
     """Unique name designating this space."""
-    cohort: str = attr.ib(init=False, default=None)
+    cohort = attr.ib(init=False, default=None, type=str)
     """An attribute to accomodate cohorts from TemplateFlow."""
-    spec: typing.Dict = attr.ib(factory=dict)
+    spec = attr.ib(factory=dict)
     """The dictionary of specs."""
-    standard: bool = attr.ib(default=False, repr=False)
+    standard = attr.ib(default=False, repr=False, type=bool)
     """Whether this space is standard or not."""
-    dim: int = attr.ib(default=3, repr=False)
+    dim = attr.ib(default=3, repr=False, type=int)
     """Dimensionality of the sampling manifold."""
 
     def __attrs_post_init__(self):

--- a/niworkflows/utils/spaces.py
+++ b/niworkflows/utils/spaces.py
@@ -246,7 +246,6 @@ class Space:
         return [cls(_args[0], s) for s in allspecs]
 
 
-
 class SpatialReferences:
     """
     Manage specifications of spatial references.

--- a/niworkflows/utils/spaces.py
+++ b/niworkflows/utils/spaces.py
@@ -53,7 +53,7 @@ class Space:
     >>> Space('func')
     Space(name='func', cohort=None, spec={})
 
-    Checks spaces with cohorts:
+    >>> # Checks spaces with cohorts:
     >>> Space('MNIPediatricAsym')
     Traceback (most recent call last):
       ...
@@ -82,13 +82,13 @@ class Space:
     ValueError: space identifier "shouldraise" is invalid.
     ...
 
-    Correctly assigns the density of legacy "fsaverage":
+    >>> # Correctly assigns the density of legacy "fsaverage":
     >>> Space(name='fsaverage')
     Space(name='fsaverage', cohort=None, spec={'den': '164k'})
     >>> Space(name='fsaverage6')
     Space(name='fsaverage', cohort=None, spec={'den': '41k'})
 
-    Overwrites density of legacy "fsaverage" specifications
+    >>> # Overwrites density of legacy "fsaverage" specifications
     >>> Space(name='fsaverage6', spec={'den': '10k'})
     Space(name='fsaverage', cohort=None, spec={'den': '41k'})
 

--- a/niworkflows/utils/spaces.py
+++ b/niworkflows/utils/spaces.py
@@ -1,4 +1,5 @@
 """Utilities for tracking and filtering spaces."""
+import argparse
 import attr
 from collections import defaultdict
 from itertools import product
@@ -363,8 +364,8 @@ class SpatialReferences:
     def check_space(space):
         """Build a :class:`Space` object."""
         try:
-            if isinstance(space[0], Space):
-                return space[0]
+            if isinstance(space, Space):
+                return space
         except IndexError:
             pass
 
@@ -415,7 +416,7 @@ class SpatialReferences:
 
     def __repr__(self):
         """Representation of this object."""
-        return 'Imaging spaces: %s' % ', '.join(self._spaces)
+        return 'Imaging spaces: %s' % ', '.join([s.fullname for s in self.spaces])
 
     @property
     def spaces(self):
@@ -476,6 +477,14 @@ class SpatialReferences:
                 if s.name in ("fsaverage", "fsnative")]
 
 
+class StoreSpacesAction(argparse.Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        spaces = getattr(namespace, self.dest) or []
+        for val in values:
+            spaces.extend(Space.from_string(val))
+        setattr(namespace, self.dest, spaces)
+
+
 def hasspec(value, specs):
     """Check whether any of the keys are in a dict."""
     for s in specs:
@@ -492,7 +501,6 @@ def _expand_entities(entities):
 
 
     .. testsetup::
-
         >>> if PY_VERSION < (3, 6):
         ...     pytest.skip("This doctest does not work on python <3.6")
 

--- a/niworkflows/utils/spaces.py
+++ b/niworkflows/utils/spaces.py
@@ -220,6 +220,11 @@ class Space:
         """
         Parse a string to generate the corresponding list of Spaces.
 
+        .. testsetup::
+
+            >>> if PY_VERSION < (3, 6):
+            ...     pytest.skip("This doctest does not work on python <3.6")
+
         Parameters
         ----------
         value: :obj:`str`
@@ -257,6 +262,7 @@ class Space:
         >>> Space.from_string("MNIPediatricAsym:cohort-1:cohort-2")
         [Space(name='MNIPediatricAsym', spec={'cohort': '1'}),
          Space(name='MNIPediatricAsym', spec={'cohort': '2'})]
+
 
         >>> Space.from_string("MNIPediatricAsym:cohort-5:cohort-6:res-2")
         [Space(name='MNIPediatricAsym', spec={'cohort': '5', 'res': '2'}),

--- a/niworkflows/utils/spaces.py
+++ b/niworkflows/utils/spaces.py
@@ -1,0 +1,364 @@
+"""Utilities for tracking and filtering spaces."""
+import attr
+import typing
+from templateflow import api as _tfapi
+
+NONSTANDARD_REFERENCES = [
+    'T1w',
+    'T2w',
+    'anat',
+    'fsnative',
+    'func',
+    'run',
+    'sbref',
+    'session',
+]
+"""List of supported nonstandard reference spaces."""
+
+
+FSAVERAGE_DENSITY = {
+    'fsaverage3': '642',
+    'fsaverage4': '2562',
+    'fsaverage5': '10k',
+    'fsaverage6': '41k',
+    'fsaverage': '164k',
+}
+"""A map of surface densities and legacy fsaverageX names."""
+
+
+@attr.s(slots=True, frozen=True)
+class Space:
+    """
+    Represent a (non)standard space specification.
+
+    Examples
+    --------
+    >>> Space('MNI152NLin2009cAsym')
+    Space(name='MNI152NLin2009cAsym', cohort=None, spec={})
+
+    >>> Space('MNI152NLin2009cAsym', {})
+    Space(name='MNI152NLin2009cAsym', cohort=None, spec={})
+
+    >>> Space('MNI152NLin2009cAsym', None)
+    Space(name='MNI152NLin2009cAsym', cohort=None, spec={})
+
+    >>> Space('MNI152NLin2009cAsym', {'res': 1})
+    Space(name='MNI152NLin2009cAsym', cohort=None, spec={'res': 1})
+
+    >>> Space('MNIPediatricAsym', {'cohort': '1'})
+    Space(name='MNIPediatricAsym', cohort='1', spec={})
+
+    >>> Space('func')
+    Space(name='func', cohort=None, spec={})
+
+    Checks spaces with cohorts:
+    >>> Space('MNIPediatricAsym')
+    Traceback (most recent call last):
+      ...
+    ValueError: standard space "MNIPediatricAsym" is not fully defined.
+    ...
+
+    >>> Space(name='MNI152Lin', spec={'cohort': 1})
+    Traceback (most recent call last):
+      ...
+    ValueError: standard space "MNI152Lin" does not contain ...
+
+    >>> Space('MNIPediatricAsym', {'cohort': '100'})
+    Traceback (most recent call last):
+      ...
+    ValueError: standard space "MNIPediatricAsym" does not contain ...
+    ...
+
+    >>> Space('MNIPediatricAsym', 'blah')
+    Traceback (most recent call last):
+      ...
+    TypeError: invalid space specification...
+
+    >>> Space('shouldraise')
+    Traceback (most recent call last):
+      ...
+    ValueError: space identifier "shouldraise" is invalid.
+    ...
+
+    Correctly assigns the density of legacy "fsaverage":
+    >>> Space(name='fsaverage')
+    Space(name='fsaverage', cohort=None, spec={'den': '164k'})
+    >>> Space(name='fsaverage6')
+    Space(name='fsaverage', cohort=None, spec={'den': '41k'})
+
+    Overwrites density of legacy "fsaverage" specifications
+    >>> Space(name='fsaverage6', spec={'den': '10k'})
+    Space(name='fsaverage', cohort=None, spec={'den': '41k'})
+
+    >>> Space('func').standard
+    False
+
+    >>> Space('MNI152Lin').standard
+    True
+
+    >>> Space('MNIPediatricAsym', {'cohort': 1}).standard
+    True
+
+    >>> Space('func') == Space('func')
+    True
+
+    >>> Space('func') != Space('MNI152Lin')
+    True
+
+    >>> Space('MNI152Lin', {'res': 1}) == Space('MNI152Lin', {'res': 1})
+    True
+
+    >>> Space('MNI152Lin', {'res': 1}) == Space('MNI152Lin', {'res': 2})
+    False
+
+    >>> sp1 = Space('MNIPediatricAsym', {'cohort': 1})
+    >>> sp2 = Space('MNIPediatricAsym', {'cohort': 2})
+    >>> sp1 == sp2
+    False
+
+    >>> sp1 = Space('MNIPediatricAsym', {'res': 1, 'cohort': 1})
+    >>> sp2 = Space('MNIPediatricAsym', {'cohort': 1, 'res': 1})
+    >>> sp1 == sp2
+    True
+
+    """
+
+    _standard_spaces = tuple(_tfapi.templates())
+
+    name: str = attr.ib(default=None)
+    """Unique name designating this space."""
+    cohort: str = attr.ib(init=False, default=None)
+    """An attribute to accomodate cohorts from TemplateFlow."""
+    spec: typing.Dict = attr.ib(factory=dict)
+    """The dictionary of specs."""
+    standard: bool = attr.ib(default=False, repr=False)
+    """Whether this space is standard or not."""
+    dim: bool = attr.ib(default=3, repr=False)
+    """Dimensionality of the sampling manifold."""
+
+    def __attrs_post_init__(self):
+        """Extract cohort out of spec."""
+        if self.spec is None:
+            object.__setattr__(self, "spec", {})
+
+        if self.name.startswith('fsaverage'):
+            name = self.name
+            object.__setattr__(self, "name", "fsaverage")
+
+            if 'den' not in self.spec or name != "fsaverage":
+                spec = self.spec.copy()
+                spec['den'] = FSAVERAGE_DENSITY[name]
+                object.__setattr__(self, "spec", spec)
+
+        if self.name.startswith('fs'):
+            object.__setattr__(self, "dim", 2)
+
+        if self.name in self._standard_spaces:
+            object.__setattr__(self, "standard", True)
+
+        if self.spec and 'cohort' in self.spec:
+            spec = self.spec.copy()
+            value = spec.pop('cohort')
+            self._check_cohort('cohort', value)
+            object.__setattr__(self, "cohort", value)
+            object.__setattr__(self, "spec", spec)
+            return
+
+        _cohorts = _tfapi.TF_LAYOUT.get_cohorts(template=self.name)
+        if _cohorts:
+            _cohorts = ', '.join(['"cohort-%s"' % c for c in _cohorts])
+            raise ValueError(
+                'standard space "%s" is not fully defined.\n'
+                'Set a valid cohort selector from: %s.' % (self.name, _cohorts))
+
+    @name.validator
+    def _check_name(self, attribute, value):
+        if value.startswith('fsaverage'):
+            return
+        valid = list(self._standard_spaces) + NONSTANDARD_REFERENCES
+        if value not in valid:
+            raise ValueError(
+                'space identifier "%s" is invalid.\nValid '
+                'identifiers are: %s' % (value, ', '.join(valid)))
+
+    @cohort.validator
+    def _check_cohort(self, attribute, value):
+        valid = ['%s' % c for c in _tfapi.TF_LAYOUT.get_cohorts(
+            template=self.name)]
+        if value is not None and str(value) not in valid:
+            raise ValueError(
+                'standard space "%s" does not contain any cohort '
+                'named "%s".' % (self.name, value))
+
+    @spec.validator
+    def _check_spec(self, attribute, value):
+        if value is not None and not isinstance(value, dict):
+            raise TypeError(
+                "invalid space specification: %s." % str(value))
+
+
+class SpatialReferences:
+    """
+    Manage specifications of spatial references.
+
+    Examples
+    --------
+    >>> sp = SpatialReferences([
+    ...     'func',
+    ...     'fsnative',
+    ...     'MNI152NLin2009cAsym',
+    ...     'anat',
+    ...     'fsaverage5',
+    ...     'fsaverage6',
+    ...     ('MNIPediatricAsym', {'cohort': '2'}),
+    ...     ('MNI152NLin2009cAsym', {'res': 2}),
+    ...     ('MNI152NLin2009cAsym', {'res': 1}),
+    ... ])
+    >>> sp.get_nonstd_spaces()
+    ['func', 'fsnative', 'anat']
+
+    >>> sp.get_nonstd_spaces(dim=(3,))
+    ['func', 'anat']
+
+    >>> sp.get_std_spaces()
+    ['MNI152NLin2009cAsym', 'fsaverage', 'MNIPediatricAsym:cohort-2']
+
+    >>> sp.get_std_spaces(dim=(3,))
+    ['MNI152NLin2009cAsym', 'MNIPediatricAsym:cohort-2']
+
+    >>> sp.get_templates()
+    [Space(name='fsaverage', cohort=None, spec={'den': '10k'}),
+     Space(name='fsaverage', cohort=None, spec={'den': '41k'}),
+     Space(name='MNI152NLin2009cAsym', cohort=None, spec={'res': 2}),
+     Space(name='MNI152NLin2009cAsym', cohort=None, spec={'res': 1})]
+
+    >>> sp.add(('MNIPediatricAsym', {'cohort': '2'}))
+    >>> sp.get_std_spaces(dim=(3,))
+    ['MNI152NLin2009cAsym', 'MNIPediatricAsym:cohort-2']
+
+    >>> sp += [('MNIPediatricAsym', {'cohort': '2'})]
+    Traceback (most recent call last):
+      ...
+    ValueError: space ...
+
+    >>> sp += [('MNIPediatricAsym', {'cohort': '1'})]
+    >>> sp.get_std_spaces(dim=(3,))
+    ['MNI152NLin2009cAsym', 'MNIPediatricAsym:cohort-2', 'MNIPediatricAsym:cohort-1']
+
+    >>> sp.insert(0, ('MNIPediatricAsym', {'cohort': '3'}))
+    >>> sp.get_std_spaces(dim=(3,))
+    ['MNIPediatricAsym:cohort-3',
+     'MNI152NLin2009cAsym',
+     'MNIPediatricAsym:cohort-2',
+     'MNIPediatricAsym:cohort-1']
+
+    >>> sp.insert(0, ('MNIPediatricAsym', {'cohort': '3'}))
+    Traceback (most recent call last):
+      ...
+    ValueError: space ...
+
+    """
+
+    __slots__ = ('_spaces')
+    standard_spaces = tuple(_tfapi.templates())
+    """List of supported standard reference spaces."""
+
+    @staticmethod
+    def check_space(space):
+        """Build a :class:`Space` object."""
+        spec = {}
+        if not isinstance(space, str):
+            try:
+                spec = space[1] or {}
+            except IndexError:
+                pass
+            except TypeError:
+                space = (None, )
+
+            space = space[0]
+        return Space(space, spec)
+
+    def __init__(self, spaces=None):
+        """
+        Maintain the bookkeeping of spaces and templates.
+
+        Internal spaces are normalizations required for pipeline execution which
+        can vary based on user arguments.
+        Output spaces are desired user outputs.
+        """
+        self._spaces = []
+        if spaces is not None:
+            if isinstance(spaces, str):
+                spaces = [spaces]
+            self.__add__(spaces)
+
+    def __add__(self, b):
+        """Append a list of transforms to the internal list."""
+        if not isinstance(b, (list, tuple)):
+            raise TypeError('Must be a list.')
+
+        for space in b:
+            self.append(space)
+        return self
+
+    def __contains__(self, item):
+        """Implement the ``in`` builtin."""
+        if not self._spaces:
+            return False
+        item = self.check_space(item)
+        return any([i == item for i in self._spaces])
+
+    def __repr__(self):
+        """Representation of this object."""
+        return 'Imaging spaces: %s' % ', '.join(self._spaces)
+
+    @property
+    def spaces(self):
+        """Get all specified spaces."""
+        return self._spaces
+
+    @spaces.setter
+    def spaces(self, value):
+        self._spaces = value
+
+    def add(self, value):
+        """Add one more space, without erroring if it exists."""
+        if value not in self:
+            self.spaces += [self.check_space(value)]
+
+    def append(self, value):
+        """Concatenate one more space."""
+        if value not in self:
+            self.spaces += [self.check_space(value)]
+            return
+
+        raise ValueError('space "%s" already in spaces.' % str(value))
+
+    def insert(self, index, value, error=True):
+        """Concatenate one more space."""
+        if value not in self:
+            self.spaces.insert(index, self.check_space(value))
+        elif error is True:
+            raise ValueError('space "%s" already in spaces.' % str(value))
+
+    def get_std_spaces(self, dim=(2, 3)):
+        """Return only standard spaces."""
+        _names = [':cohort-'.join((s.name, s.cohort))
+                  if s.cohort else s.name
+                  for s in self._spaces if s.standard and s.dim in dim]
+
+        names = []
+        for s in _names:
+            if s not in names:
+                names.append(s)
+        return names
+
+    def get_templates(self, dim=(2, 3)):
+        """Return output spaces."""
+        return [s for s in self._spaces
+                if s.standard and s.spec and s.dim in dim]
+
+    def get_nonstd_spaces(self, dim=(2, 3)):
+        """Return nonstandard spaces."""
+        return [s.name for s in self._spaces
+                if not s.standard and s.dim in dim]

--- a/niworkflows/utils/spaces.py
+++ b/niworkflows/utils/spaces.py
@@ -355,7 +355,7 @@ class SpatialReferences:
 
     """
 
-    __slots__ = ('_spaces')
+    __slots__ = ('_spaces',)
     standard_spaces = tuple(_tfapi.templates())
     """List of supported standard reference spaces."""
 

--- a/niworkflows/utils/spaces.py
+++ b/niworkflows/utils/spaces.py
@@ -501,12 +501,12 @@ def _expand_entities(entities):
     >>> entities = {'subject': ['01', '02'], 'session': ['1', '2'], 'task': ['rest', 'finger']}
     >>> _expand_entities(entities)
     [{'subject': '01', 'session': '1', 'task': 'rest'},
-     {'subject': '02', 'session': '1', 'task': 'rest'},
-     {'subject': '01', 'session': '2', 'task': 'rest'},
-     {'subject': '02', 'session': '2', 'task': 'rest'},
      {'subject': '01', 'session': '1', 'task': 'finger'},
-     {'subject': '02', 'session': '1', 'task': 'finger'},
+     {'subject': '01', 'session': '2', 'task': 'rest'},
      {'subject': '01', 'session': '2', 'task': 'finger'},
+     {'subject': '02', 'session': '1', 'task': 'rest'},
+     {'subject': '02', 'session': '1', 'task': 'finger'},
+     {'subject': '02', 'session': '2', 'task': 'rest'},
      {'subject': '02', 'session': '2', 'task': 'finger'}]
 
     """

--- a/niworkflows/utils/spaces.py
+++ b/niworkflows/utils/spaces.py
@@ -84,53 +84,27 @@ class Space:
     ValueError: space identifier "shouldraise" is invalid.
     ...
 
-    >>> # Correctly assigns the density of legacy "fsaverage":
-    >>> Space(name='fsaverage')
-    Space(name='fsaverage', spec={'den': '164k'})
-    >>> Space(name='fsaverage').legacyname
-    'fsaverage'
-    >>> Space(name='fsaverage6')
-    Space(name='fsaverage', spec={'den': '41k'})
-    >>> Space(name='fsaverage6').legacyname
-    'fsaverage6'
-    >>> # Overwrites density of legacy "fsaverage" specifications
-    >>> Space(name='fsaverage6', spec={'den': '10k'})
-    Space(name='fsaverage', spec={'den': '41k'})
-    >>> Space(name='fsaverage6', spec={'den': '10k'}).legacyname
-    'fsaverage6'
-
+    # Check standard property
     >>> Space('func').standard
     False
-
     >>> Space('MNI152Lin').standard
     True
-
-    >>> Space('MNI152Lin').fullname
-    'MNI152Lin'
-
     >>> Space('MNIPediatricAsym', {'cohort': 1}).standard
     True
 
-    >>> Space('MNIPediatricAsym', {'cohort': 1}).fullname
-    'MNIPediatricAsym:cohort-1'
-
+    >>> # Equality/inequality checks
     >>> Space('func') == Space('func')
     True
-
     >>> Space('func') != Space('MNI152Lin')
     True
-
     >>> Space('MNI152Lin', {'res': 1}) == Space('MNI152Lin', {'res': 1})
     True
-
     >>> Space('MNI152Lin', {'res': 1}) == Space('MNI152Lin', {'res': 2})
     False
-
     >>> sp1 = Space('MNIPediatricAsym', {'cohort': 1})
     >>> sp2 = Space('MNIPediatricAsym', {'cohort': 2})
     >>> sp1 == sp2
     False
-
     >>> sp1 = Space('MNIPediatricAsym', {'res': 1, 'cohort': 1})
     >>> sp2 = Space('MNIPediatricAsym', {'cohort': 1, 'res': 1})
     >>> sp1 == sp2
@@ -189,14 +163,44 @@ class Space:
 
     @property
     def fullname(self):
-        """Generate a full-name combining cohort."""
+        """
+        Generate a full-name combining cohort.
+
+        Examples
+        --------
+        >>> Space('MNI152Lin').fullname
+        'MNI152Lin'
+
+        >>> Space('MNIPediatricAsym', {'cohort': 1}).fullname
+        'MNIPediatricAsym:cohort-1'
+
+        """
         if "cohort" not in self.spec:
             return self.name
         return "%s:cohort-%s" % (self.name, self.spec["cohort"])
 
     @property
     def legacyname(self):
-        """Generate a legacy name for fsaverageX spaces."""
+        """
+        Generate a legacy name for fsaverageX spaces.
+
+        Examples
+        --------
+        >>> Space(name='fsaverage')
+        Space(name='fsaverage', spec={'den': '164k'})
+        >>> Space(name='fsaverage').legacyname
+        'fsaverage'
+        >>> Space(name='fsaverage6')
+        Space(name='fsaverage', spec={'den': '41k'})
+        >>> Space(name='fsaverage6').legacyname
+        'fsaverage6'
+        >>> # Overwrites density of legacy "fsaverage" specifications
+        >>> Space(name='fsaverage6', spec={'den': '10k'})
+        Space(name='fsaverage', spec={'den': '41k'})
+        >>> Space(name='fsaverage6', spec={'den': '10k'}).legacyname
+        'fsaverage6'
+
+        """
         if self.name == "fsaverage":
             return FSAVERAGE_LEGACY[self.spec["den"]]
 

--- a/niworkflows/utils/spaces.py
+++ b/niworkflows/utils/spaces.py
@@ -201,9 +201,12 @@ class Space:
         Space(name='fsaverage', spec={'den': '41k'})
         >>> Space(name='fsaverage6', spec={'den': '10k'}).legacyname
         'fsaverage6'
+        >>> # Return None if no legacy name
+        >>> Space(name='fsaverage', spec={'den': '30k'}).legacyname is None
+        True
 
         """
-        if self.name == "fsaverage":
+        if self.name == "fsaverage" and self.spec["den"] in FSAVERAGE_LEGACY:
             return FSAVERAGE_LEGACY[self.spec["den"]]
 
     @name.validator
@@ -506,7 +509,8 @@ class OutputSpacesAction(argparse.Action):
         """Execute parser."""
         spaces = getattr(namespace, self.dest) or SpatialReferences()
         for val in values:
-            spaces += Space.from_string(val)
+            for sp in Space.from_string(val):
+                spaces.add(sp)
         setattr(namespace, self.dest, spaces)
 
 

--- a/niworkflows/utils/spaces.py
+++ b/niworkflows/utils/spaces.py
@@ -169,7 +169,7 @@ class Space:
     """The dictionary of specs."""
     standard: bool = attr.ib(default=False, repr=False)
     """Whether this space is standard or not."""
-    dim: bool = attr.ib(default=3, repr=False)
+    dim: int = attr.ib(default=3, repr=False)
     """Dimensionality of the sampling manifold."""
 
     def __attrs_post_init__(self):

--- a/niworkflows/utils/spaces.py
+++ b/niworkflows/utils/spaces.py
@@ -76,7 +76,7 @@ class Space:
     >>> Space('MNIPediatricAsym', 'blah')
     Traceback (most recent call last):
       ...
-    TypeError: invalid space specification...
+    TypeError: ...
 
     >>> Space('shouldraise')
     Traceback (most recent call last):
@@ -116,7 +116,8 @@ class Space:
 
     name = attr.ib(default=None, type=str)
     """Unique name designating this space."""
-    spec = attr.ib(factory=dict)
+    spec = attr.ib(factory=dict, validator=attr.validators.optional(
+        attr.validators.instance_of(dict)))
     """The dictionary of specs."""
     standard = attr.ib(default=False, repr=False, type=bool)
     """Whether this space is standard or not."""
@@ -213,12 +214,6 @@ class Space:
             raise ValueError(
                 'space identifier "%s" is invalid.\nValid '
                 'identifiers are: %s' % (value, ', '.join(valid)))
-
-    @spec.validator
-    def _check_spec(self, attribute, value):
-        if value is not None and not isinstance(value, dict):
-            raise TypeError(
-                "invalid space specification: %s." % str(value))
 
     @classmethod
     def from_string(cls, value):

--- a/niworkflows/utils/spaces.py
+++ b/niworkflows/utils/spaces.py
@@ -220,6 +220,10 @@ class SpatialReferences:
     >>> sp.get_nonstd_spaces(dim=(3,))
     ['func', 'anat']
 
+    >>> sp.get_nonstd_spaces(only_names=False, dim=(3,))
+    [Space(name='func', cohort=None, spec={}),
+     Space(name='anat', cohort=None, spec={})]
+
     >>> sp.get_std_spaces()
     ['MNI152NLin2009cAsym', 'fsaverage', 'MNIPediatricAsym:cohort-2']
 
@@ -358,7 +362,8 @@ class SpatialReferences:
         return [s for s in self._spaces
                 if s.standard and s.spec and s.dim in dim]
 
-    def get_nonstd_spaces(self, dim=(2, 3)):
+    def get_nonstd_spaces(self, only_names=True, dim=(2, 3)):
         """Return nonstandard spaces."""
-        return [s.name for s in self._spaces
+        return [s.name if only_names else s
+                for s in self._spaces
                 if not s.standard and s.dim in dim]

--- a/niworkflows/utils/spaces.py
+++ b/niworkflows/utils/spaces.py
@@ -496,10 +496,32 @@ class SpatialReferences:
                 if not s.standard and s.dim in dim]
 
     def get_fs_spaces(self):
-        """Return FreeSurfer spaces."""
+        """
+        Return FreeSurfer spaces.
+
+        Discards nonlegacy fsaverage values (i.e., with nonstandard density value).
+
+        Examples
+        --------
+        >>> SpatialReferences([
+        ...     'fsnative',
+        ...     'fsaverage6',
+        ...     'fsaverage5',
+        ...     'MNI152NLin6Asym',
+        ... ]).get_fs_spaces()
+        ['fsnative', 'fsaverage6', 'fsaverage5']
+
+        >>> SpatialReferences([
+        ...     'fsnative',
+        ...     'fsaverage6',
+        ...     Space(name='fsaverage', spec={'den': '30k'})
+        ... ]).get_fs_spaces()
+        ['fsnative', 'fsaverage6']
+
+        """
         return [s.legacyname or s.name
                 for s in self._spaces
-                if s.name in ("fsaverage", "fsnative")]
+                if s.legacyname or s.name == "fsnative"]
 
 
 class OutputSpacesAction(argparse.Action):

--- a/niworkflows/utils/tests/test_spaces.py
+++ b/niworkflows/utils/tests/test_spaces.py
@@ -1,0 +1,28 @@
+import pytest
+
+from ..spaces import Space, SpatialReferences, StoreSpacesAction
+
+
+@pytest.fixture
+def parser():
+    import argparse
+
+    pars = argparse.ArgumentParser()
+    pars.add_argument('--spaces', nargs='+', action=StoreSpacesAction,
+                      help='user defined spaces')
+    return pars
+
+
+@pytest.mark.parametrize("spaces,expected", [
+    (("MNI152NLin6Asym",), 1),
+    (("fsaverage:den-10k", "MNI152NLin6Asym"), 2),
+    (("fsaverage:den-10k:den-30k", "MNI152NLin6Asym:res-1:res-2"), 4),
+])
+def test_space_action(parser, spaces, expected):
+    pargs = parser.parse_args(args=('--spaces',) + spaces)
+    parsed_spaces = pargs.spaces
+    assert all(isinstance(sp, Space) for sp in parsed_spaces), "Every element must be a `Space`"
+
+    sparef = SpatialReferences()
+    sparef += parsed_spaces
+    assert len(sparef.spaces) == len(parsed_spaces) == expected

--- a/niworkflows/utils/tests/test_spaces.py
+++ b/niworkflows/utils/tests/test_spaces.py
@@ -18,6 +18,10 @@ def parser():
     (("MNI152NLin6Asym",), 1),
     (("fsaverage:den-10k", "MNI152NLin6Asym"), 2),
     (("fsaverage:den-10k:den-30k", "MNI152NLin6Asym:res-1:res-2"), 4),
+    (("fsaverage:den-10k:den-30k", "MNI152NLin6Asym:res-1:res-2",
+      "fsaverage5"), 4),
+    (("fsaverage:den-10k:den-30k", "MNI152NLin6Asym:res-1:res-2",
+      "fsaverage:den-10k:den-30k", "MNI152NLin6Asym:res-1:res-2"), 4),
 ])
 def test_space_action(parser, spaces, expected):
     """Test action."""

--- a/niworkflows/utils/tests/test_spaces.py
+++ b/niworkflows/utils/tests/test_spaces.py
@@ -1,14 +1,15 @@
+"""Test spaces."""
 import pytest
-
-from ..spaces import Space, SpatialReferences, StoreSpacesAction
+from ..spaces import Space, SpatialReferences, OutputSpacesAction
 
 
 @pytest.fixture
 def parser():
+    """Create a parser."""
     import argparse
 
     pars = argparse.ArgumentParser()
-    pars.add_argument('--spaces', nargs='+', action=StoreSpacesAction,
+    pars.add_argument('--spaces', nargs='+', action=OutputSpacesAction,
                       help='user defined spaces')
     return pars
 
@@ -19,10 +20,10 @@ def parser():
     (("fsaverage:den-10k:den-30k", "MNI152NLin6Asym:res-1:res-2"), 4),
 ])
 def test_space_action(parser, spaces, expected):
+    """Test action."""
     pargs = parser.parse_args(args=('--spaces',) + spaces)
     parsed_spaces = pargs.spaces
-    assert all(isinstance(sp, Space) for sp in parsed_spaces), "Every element must be a `Space`"
-
-    sparef = SpatialReferences()
-    sparef += parsed_spaces
-    assert len(sparef.spaces) == len(parsed_spaces) == expected
+    assert isinstance(parsed_spaces, SpatialReferences)
+    assert all(isinstance(sp, Space) for sp in parsed_spaces.spaces), \
+        "Every element must be a `Space`"
+    assert len(parsed_spaces.spaces) == expected

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ classifiers =
 [options]
 python_requires = >= 3.5
 install_requires =
+    attrs
     jinja2
     matplotlib >= 2.2.0 ; python_version >= "3.6"
     matplotlib >= 2.2.0, < 3.1 ; python_version < "3.6"
@@ -109,7 +110,7 @@ per-file-ignores =
 [tool:pytest]
 norecursedirs = .git
 addopts = -svx --doctest-modules
-doctest_optionflags = ALLOW_UNICODE NORMALIZE_WHITESPACE
+doctest_optionflags = ALLOW_UNICODE NORMALIZE_WHITESPACE ELLIPSIS
 env =
     PYTHONHASHSEED=0
 filterwarnings =


### PR DESCRIPTION
(brought in from mgxd/niworkflows#1)

Okay, after much thinking, I believe this captures the whole set of requirements.

Now there is an ``Space`` object that makes all the validations and sanity checks. There is still room for enhancements:
- ~~We might want to implement a classmethod (something like ``Space.from_string``) that implements the parsing of ``--output-spaces`` arguments (see https://www.attrs.org/en/stable/init.html).~~ DONE
- We might want to check that the specs contain valid keywords against templateflow (at the moment, this is only done for cohort).

Other than that, I think the doctest examples show pretty much all the functionality.

Then, the ``SpatialReferences`` class is the one in charge of sorting out the available spaces. It has three convenience methods to filter out references:
- ``get_std_spaces()`` returns template names (including cohort if necessary) that is of interest to the spatial normalizations that sMRIPrep will run.
- ``get_templates()`` returns full ``Space`` objects with the desired outputs, as set by the user.
- ``get_nonstd_spaces()`` returns nonstandard ``Space``s or their names (depending on the ``only_names`` argument)

Added tests on examples like those in https://github.com/poldracklab/fmriprep/issues/1604#issuecomment-562243214