### PR TITLE
ENH: Add cache to SpatialReferences

### DIFF
--- a/niworkflows/utils/spaces.py
+++ b/niworkflows/utils/spaces.py
@@ -335,6 +335,23 @@ class SpatialReferences:
      Space(name='MNI152NLin2009cAsym', spec={'res': 2}),
      Space(name='MNI152NLin2009cAsym', spec={'res': 1})]
 
+    >>> sp.cached
+    Traceback (most recent call last):
+     ...
+    AttributeError: Spaces have not ...
+
+    >>> sp.cache_spaces()
+    >>> sp.cached
+    (Space(name='func', spec={}),
+     Space(name='fsnative', spec={}),
+     Space(name='MNI152NLin2009cAsym', spec={}),
+     Space(name='anat', spec={}),
+     Space(name='fsaverage', spec={'den': '10k'}),
+     Space(name='fsaverage', spec={'den': '41k'}),
+     Space(name='MNIPediatricAsym', spec={'cohort': '2'}),
+     Space(name='MNI152NLin2009cAsym', spec={'res': 2}),
+     Space(name='MNI152NLin2009cAsym', spec={'res': 1}))
+
     >>> sp.add(('MNIPediatricAsym', {'cohort': '2'}))
     >>> sp.get_std_spaces(dim=(3,))
     ['MNI152NLin2009cAsym', 'MNIPediatricAsym:cohort-2']
@@ -360,10 +377,15 @@ class SpatialReferences:
       ...
     ValueError: space ...
 
+    >>> sp.cache_spaces()
+    Traceback (most recent call last):
+     ...
+    AttributeError: Spaces have already ...
+
     """
 
-    __slots__ = ('_spaces',)
-    standard_spaces = tuple(_tfapi.templates())
+    __slots__ = ('_spaces', '_cached')
+    _standard_spaces = tuple(_tfapi.templates())
     """List of supported standard reference spaces."""
 
     @staticmethod
@@ -396,6 +418,7 @@ class SpatialReferences:
         Output spaces are desired user outputs.
         """
         self._spaces = []
+        self._cached = None
         if spaces is not None:
             if isinstance(spaces, str):
                 spaces = [spaces]
@@ -447,6 +470,19 @@ class SpatialReferences:
     def spaces(self):
         """Get all specified spaces."""
         return self._spaces
+
+    @property
+    def cached(self):
+        """Get cached spaces. If cached has not been set, raise `AttributeError`"""
+        if self._cached is None:
+            raise AttributeError("Spaces have not been cached")
+        return self._cached
+
+    def cache_spaces(self):
+        """Cache and freeze current spaces to separate attribute"""
+        if self._cached is not None:
+            raise AttributeError("Spaces have already been cached")
+        self._cached = tuple(self.spaces)
 
     @spaces.setter
     def spaces(self, value):

--- a/niworkflows/utils/spaces.py
+++ b/niworkflows/utils/spaces.py
@@ -338,9 +338,9 @@ class SpatialReferences:
     >>> sp.cached
     Traceback (most recent call last):
      ...
-    AttributeError: Spaces have not ...
+    ValueError: Spaces have not ...
 
-    >>> sp.cache_spaces()
+    >>> sp.checkpoint()
     >>> sp.cached
     (Space(name='func', spec={}),
      Space(name='fsnative', spec={}),
@@ -377,10 +377,10 @@ class SpatialReferences:
       ...
     ValueError: space ...
 
-    >>> sp.cache_spaces()
+    >>> sp.checkpoint()
     Traceback (most recent call last):
      ...
-    AttributeError: Spaces have already ...
+    ValueError: Spaces have already ...
 
     """
 
@@ -475,13 +475,13 @@ class SpatialReferences:
     def cached(self):
         """Get cached spaces. If cached has not been set, raise `AttributeError`"""
         if self._cached is None:
-            raise AttributeError("Spaces have not been cached")
+            raise ValueError("Spaces have not been cached")
         return self._cached
 
-    def cache_spaces(self):
+    def checkpoint(self):
         """Cache and freeze current spaces to separate attribute"""
         if self._cached is not None:
-            raise AttributeError("Spaces have already been cached")
+            raise ValueError("Spaces have already been cached")
         self._cached = tuple(self.spaces)
 
     @spaces.setter

--- a/niworkflows/utils/spaces.py
+++ b/niworkflows/utils/spaces.py
@@ -385,7 +385,7 @@ class SpatialReferences:
     """
 
     __slots__ = ('_spaces', '_cached')
-    _standard_spaces = tuple(_tfapi.templates())
+    standard_spaces = tuple(_tfapi.templates())
     """List of supported standard reference spaces."""
 
     @staticmethod


### PR DESCRIPTION
- adds `cached` property to allow checkpointing `spaces`.
  - this can be leveraged to differentiate user requested spaces
- make `SpatialReferences` standard spaces class attribute private