### PR TITLE
ENH: Revise SpatialReference caching for ease of use, accessibility

### DIFF
--- a/niworkflows/utils/spaces.py
+++ b/niworkflows/utils/spaces.py
@@ -331,12 +331,16 @@ class SpatialReferences:
      Reference(space='MNI152NLin2009cAsym', spec={'res': 2}),
      Reference(space='MNI152NLin2009cAsym', spec={'res': 1})]
 
+    >>> sp.is_cached()
+    False
     >>> sp.cached
     Traceback (most recent call last):
      ...
     ValueError: References have not ...
 
     >>> sp.checkpoint()
+    >>> sp.is_cached()
+    True
     >>> sp.cached.references
     [Reference(space='func', spec={}),
      Reference(space='fsnative', spec={}),

--- a/niworkflows/utils/spaces.py
+++ b/niworkflows/utils/spaces.py
@@ -490,7 +490,7 @@ class SpatialReferences:
     @property
     def cached(self):
         """Get cached spaces, raise error if not cached."""
-        if self._cached is None:
+        if not self.is_cached():
             raise ValueError("References have not been cached")
         return self._cached
 
@@ -499,7 +499,7 @@ class SpatialReferences:
 
     def checkpoint(self, force=False):
         """Cache and freeze current spaces to separate attribute."""
-        if self._cached is not None and not force:
+        if self.is_cached() and not force:
             raise ValueError("References have already been cached")
         self._cached = self.__class__(self.references)
 

--- a/niworkflows/utils/tests/test_spaces.py
+++ b/niworkflows/utils/tests/test_spaces.py
@@ -9,7 +9,10 @@ def parser():
     import argparse
 
     pars = argparse.ArgumentParser()
-    pars.add_argument('--spaces', nargs='+', action=OutputReferencesAction,
+    pars.add_argument('--spaces',
+                      nargs='*',
+                      default=SpatialReferences(),
+                      action=OutputReferencesAction,
                       help='user defined spaces')
     return pars
 
@@ -25,9 +28,16 @@ def parser():
 ])
 def test_space_action(parser, spaces, expected):
     """Test action."""
-    pargs = parser.parse_args(args=('--spaces',) + spaces)
+    pargs = parser.parse_known_args(args=('--spaces',) + spaces)[0]
     parsed_spaces = pargs.spaces
     assert isinstance(parsed_spaces, SpatialReferences)
     assert all(isinstance(sp, Reference) for sp in parsed_spaces.references), \
         "Every element must be a `Reference`"
     assert len(parsed_spaces.references) == expected
+
+
+@pytest.mark.parametrize("flag,expected", [(('--spaces',), True), (None, False)])
+def test_space_action_edgecases(parser, flag, expected):
+    pargs = parser.parse_known_args(flag)[0]
+    spaces = pargs.spaces
+    assert spaces.is_cached() is expected


### PR DESCRIPTION
to add support for poldracklab/fmriprep#1979

This adds a `checkpoint()` call in `OutputReferencesAction` when the flag attached to the action is used with no arguments.